### PR TITLE
Initial checkin of authz SDK + sample app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # AuthZ SDK - Golang
 
-This repo contains the client SDK for UserClouds AuthZ service.
+This repo contains the client SDK for UserClouds AuthZ & IDP services as well as a sample app to demonstrate use of the AuthZ service.
+
+
+## AuthZ Sample
+
+To run the sample from the root of the repo:
+1. `cd samples/basic`
+2. `cp .env.example .env`
+3. Open `.env` in a text editor of your choice and fill in the Tenant URL, Client ID, and Client Secret from the UserClouds console. You can find this information in the `Plex` settings page (you may need to expand the `Plex Apps` section for the Client ID & Secret)
+2. `go run *.go` -> this runs a command line app which talks to your UserClouds tenant, creates test users & AuthZ objects/ACLs, and runs through some test scenarios. At the end, it will display a sample file/directory tree with permissions on each node of the tree.

--- a/authz/client.go
+++ b/authz/client.go
@@ -1,0 +1,482 @@
+package authz
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/jsonclient"
+	"userclouds.com/infra/ucdb"
+	"userclouds.com/infra/ucerr"
+)
+
+// Client is a client for the authz service
+type Client struct {
+	client *jsonclient.Client
+
+	// TODO: these should timeout at some point :)
+	// TODO: slightly more abstract cache interface here?
+	objectTypes  map[string]ObjectType
+	mObjectTypes sync.RWMutex
+
+	edgeTypes  map[string]EdgeType
+	mEdgeTypes sync.RWMutex
+
+	objects  map[uuid.UUID]Object
+	mObjects sync.RWMutex
+
+	edges  map[uuid.UUID]Edge
+	mEdges sync.RWMutex
+}
+
+// NewClient creates a new authz client
+// Web API base URL, e.g. "http://localhost:1234".
+func NewClient(url string, opts ...jsonclient.Option) (*Client, error) {
+	c := &Client{
+		client:      jsonclient.New(strings.TrimSuffix(url, "/"), opts...),
+		objectTypes: make(map[string]ObjectType),
+		edgeTypes:   make(map[string]EdgeType),
+		objects:     make(map[uuid.UUID]Object),
+		edges:       make(map[uuid.UUID]Edge),
+	}
+	if err := c.client.ValidateBearerTokenHeader(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+	return c, nil
+}
+
+// ErrObjectNotFound is returned if an object is not found.
+var ErrObjectNotFound = ucerr.New("object not found")
+
+// ErrRelationshipTypeNotFound is returned if a relationship type name
+// (e.g. "editor") is not found.
+var ErrRelationshipTypeNotFound = ucerr.New("relationship type not found")
+
+// CreateObjectType creates a new type of object for the authz system.
+func (c *Client) CreateObjectType(ctx context.Context, id uuid.UUID, typeName string) (*ObjectType, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	req := ObjectType{
+		BaseModel: ucdb.NewBaseWithID(id),
+		TypeName:  typeName,
+	}
+	var resp ObjectType
+	if err := c.client.Post(ctx, "/authz/objecttypes", req, &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mObjectTypes.Lock()
+	defer c.mObjectTypes.Unlock()
+	c.objectTypes[resp.TypeName] = resp
+
+	return &resp, nil
+}
+
+// FindObjectTypeID resolves an object type name to an ID.
+func (c *Client) FindObjectTypeID(ctx context.Context, typeName string) (uuid.UUID, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	c.mObjectTypes.RLock()
+	if ot, ok := c.objectTypes[typeName]; ok {
+		c.mObjectTypes.RUnlock()
+		return ot.ID, nil
+	}
+	c.mObjectTypes.RUnlock()
+
+	if _, err := c.ListObjectTypes(ctx); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	// take advantage of the cache update in ListObjectTypes
+	id := c.objectTypes[typeName].ID
+	if id == uuid.Nil {
+		return uuid.Nil, ucerr.Errorf("authz object type '%s' not found", typeName)
+	}
+
+	return id, nil
+}
+
+// ListObjectTypes lists all object types in the system
+func (c *Client) ListObjectTypes(ctx context.Context) ([]ObjectType, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var resp []ObjectType
+	if err := c.client.Get(ctx, "/authz/objecttypes", &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	// reset the cache
+	newCache := make(map[string]ObjectType)
+	for _, objType := range resp {
+		newCache[objType.TypeName] = objType
+	}
+	c.mObjectTypes.Lock()
+	defer c.mObjectTypes.Unlock()
+	c.objectTypes = newCache
+
+	return resp, nil
+}
+
+// CreateEdgeType creates a new type of edge for the authz system.
+func (c *Client) CreateEdgeType(ctx context.Context, id uuid.UUID, sourceObjectTypeID, targetObjectTypeID uuid.UUID, typeName string) (*EdgeType, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	req := EdgeType{
+		BaseModel:          ucdb.NewBaseWithID(id),
+		TypeName:           typeName,
+		SourceObjectTypeID: sourceObjectTypeID,
+		TargetObjectTypeID: targetObjectTypeID,
+	}
+	var resp EdgeType
+	if err := c.client.Post(ctx, "/authz/edgetypes", req, &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mEdgeTypes.Lock()
+	defer c.mEdgeTypes.Unlock()
+	c.edgeTypes[resp.TypeName] = resp
+
+	return &resp, nil
+}
+
+// GetEdgeType gets an edge type (relationship) by its type ID.
+func (c *Client) GetEdgeType(ctx context.Context, edgeTypeID uuid.UUID) (*EdgeType, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mEdgeTypes.RLock()
+	for _, v := range c.edgeTypes {
+		if v.ID == edgeTypeID {
+			rv := v
+			c.mEdgeTypes.RUnlock()
+			return &rv, nil
+		}
+	}
+	c.mEdgeTypes.RUnlock()
+
+	var resp EdgeType
+	if err := c.client.Get(ctx, fmt.Sprintf("/authz/edgetypes/%s", edgeTypeID), &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mEdgeTypes.Lock()
+	defer c.mEdgeTypes.Unlock()
+	c.edgeTypes[resp.TypeName] = resp
+
+	return &resp, nil
+}
+
+// FindEdgeTypeID resolves an edge type name to an ID.
+func (c *Client) FindEdgeTypeID(ctx context.Context, typeName string) (uuid.UUID, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	c.mEdgeTypes.RLock()
+	if et, ok := c.edgeTypes[typeName]; ok {
+		c.mEdgeTypes.RUnlock()
+		return et.ID, nil
+	}
+	c.mEdgeTypes.RUnlock()
+
+	if _, err := c.ListEdgeTypes(ctx); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	// take advantage of the fact that ListEdgeTypes updated the cache
+	c.mEdgeTypes.RLock()
+	defer c.mEdgeTypes.RUnlock()
+	id := c.edgeTypes[typeName].ID
+
+	if id == uuid.Nil {
+		return uuid.Nil, ucerr.Errorf("authz edge type '%s' not found", typeName)
+	}
+	return id, nil
+}
+
+// ListEdgeTypes lists all available edge types
+func (c *Client) ListEdgeTypes(ctx context.Context) ([]EdgeType, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var resp []EdgeType
+	if err := c.client.Get(ctx, "/authz/edgetypes", &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	newCache := make(map[string]EdgeType) // clear and reset cache
+	for _, edgeType := range resp {
+		newCache[edgeType.TypeName] = edgeType
+	}
+
+	c.mEdgeTypes.Lock()
+	defer c.mEdgeTypes.Unlock()
+	c.edgeTypes = newCache
+
+	return resp, nil
+}
+
+// CreateObject creates a new object with a given ID, name, and type.
+func (c *Client) CreateObject(ctx context.Context, id, typeID uuid.UUID, alias string) (*Object, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	obj := Object{
+		BaseModel: ucdb.NewBaseWithID(id),
+		Alias:     alias,
+		TypeID:    typeID,
+	}
+	var resp Object
+	if err := c.client.Post(ctx, "/authz/objects", obj, &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mObjects.Lock()
+	defer c.mObjects.Unlock()
+	c.objects[resp.ID] = resp
+
+	return &resp, nil
+}
+
+// GetObject returns an object by ID.
+func (c *Client) GetObject(ctx context.Context, id uuid.UUID) (*Object, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mObjects.RLock()
+	if obj, ok := c.objects[id]; ok {
+		c.mObjects.RUnlock()
+		return &obj, nil
+	}
+	c.mObjects.RUnlock()
+
+	var resp Object
+	if err := c.client.Get(ctx, fmt.Sprintf("/authz/objects/%s", id), &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mObjects.Lock()
+	defer c.mObjects.Unlock()
+	c.objects[resp.ID] = resp
+
+	return &resp, nil
+}
+
+// GetObjectForName returns an object with a given name.
+func (c *Client) GetObjectForName(ctx context.Context, typeID uuid.UUID, name string) (*Object, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mObjects.RLock()
+	for _, obj := range c.objects {
+		if obj.TypeID == typeID && obj.Alias == name {
+			c.mObjects.RUnlock()
+			return &obj, nil
+		}
+	}
+	c.mObjects.RUnlock()
+
+	// TODO: support a name-based path, e.g. `/authz/objects/<objectname>`
+	var resp []Object
+	query := url.Values{}
+	query.Add("type_id", typeID.String())
+	query.Add("name", name)
+	if err := c.client.Get(ctx, fmt.Sprintf("/authz/objects?%s", query.Encode()), &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mObjects.Lock()
+	defer c.mObjects.Unlock()
+	for _, obj := range resp {
+		c.objects[obj.ID] = obj
+	}
+
+	if len(resp) > 0 {
+		return &resp[0], nil
+	}
+	return nil, ErrObjectNotFound
+}
+
+// DeleteObject deletes an object by ID.
+func (c *Client) DeleteObject(ctx context.Context, id uuid.UUID) error {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	// TODO: this might be a bit too "understanding" of the server behavior, is
+	// there a safer way to separate these responsibilities?
+	c.mEdges.Lock()
+	for _, e := range c.edges {
+		if e.SourceObjectID == id || e.TargetObjectID == id {
+			// NB: deleting under a range is explicitly safe in golang
+			delete(c.edges, e.ID)
+		}
+	}
+	c.mEdges.Unlock()
+
+	c.mObjects.Lock()
+	delete(c.objects, id)
+	c.mObjects.Unlock()
+
+	return ucerr.Wrap(c.client.Delete(ctx, fmt.Sprintf("/authz/objects/%s", id)))
+}
+
+// ListObjects lists all the objects
+func (c *Client) ListObjects(ctx context.Context) ([]Object, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var resp []Object
+	if err := c.client.Get(ctx, "/authz/objects", &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	newCache := make(map[uuid.UUID]Object)
+	for _, obj := range resp {
+		newCache[obj.ID] = obj
+	}
+
+	c.mObjects.Lock()
+	defer c.mObjects.Unlock()
+	c.objects = newCache
+
+	return resp, nil
+}
+
+// ListEdges lists all edges (relationships) where the given object
+// is a source or target.
+func (c *Client) ListEdges(ctx context.Context, objectID uuid.UUID) ([]Edge, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	// NB: we don't currently offer any cached reads here because it's hard to know when a "list" is current?
+	var resp []Edge
+	if err := c.client.Get(ctx, fmt.Sprintf("/authz/objects/%s/edges", objectID), &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mEdges.Lock()
+	defer c.mEdges.Unlock()
+	for _, e := range resp {
+		c.edges[e.ID] = e
+	}
+
+	return resp, nil
+}
+
+// ListEdgesBetweenObjects lists all edges (relationships) with a given source & target objct.
+func (c *Client) ListEdgesBetweenObjects(ctx context.Context, sourceObjectID, targetObjectID uuid.UUID) ([]Edge, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	// NB: we don't currently offer any cached reads here because it's hard to know when a "list" is current?
+	var resp []Edge
+	query := url.Values{}
+	query.Add("source_object_id", sourceObjectID.String())
+	query.Add("target_object_id", targetObjectID.String())
+	if err := c.client.Get(ctx, fmt.Sprintf("/authz/edges?%s", query.Encode()), &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mEdges.Lock()
+	defer c.mEdges.Unlock()
+	for _, e := range resp {
+		c.edges[e.ID] = e
+	}
+
+	return resp, nil
+}
+
+// FindEdge finds an existing edge (relationship) between two objects.
+func (c *Client) FindEdge(ctx context.Context, sourceObjectID, targetObjectID, edgeTypeID uuid.UUID) (*Edge, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	c.mEdges.RLock()
+	for _, edge := range c.edges {
+		if edge.SourceObjectID == sourceObjectID &&
+			edge.TargetObjectID == targetObjectID &&
+			edge.EdgeTypeID == edgeTypeID {
+			rv := edge
+			c.mEdges.RUnlock()
+			return &rv, nil
+		}
+	}
+	c.mEdges.RUnlock()
+
+	var resp []Edge
+	query := url.Values{}
+	query.Add("source_object_id", sourceObjectID.String())
+	query.Add("target_object_id", targetObjectID.String())
+	query.Add("edge_type_id", edgeTypeID.String())
+	if err := c.client.Get(ctx, fmt.Sprintf("/authz/edges?%s", query.Encode()), &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+	if len(resp) != 1 {
+		return nil, ucerr.Errorf("expected 1 edge from FindEdge, got %d", len(resp))
+	}
+
+	c.mEdges.Lock()
+	defer c.mEdges.Unlock()
+	c.edges[resp[0].ID] = resp[0]
+
+	return &resp[0], nil
+}
+
+// CreateEdge creates an edge (relationship) between two objects.
+func (c *Client) CreateEdge(ctx context.Context, id, sourceObjectID, targetObjectID, edgeTypeID uuid.UUID) (uuid.UUID, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	req := Edge{
+		BaseModel:      ucdb.NewBaseWithID(id),
+		EdgeTypeID:     edgeTypeID,
+		SourceObjectID: sourceObjectID,
+		TargetObjectID: targetObjectID,
+	}
+
+	if err := c.client.Post(ctx, "/authz/edges", req, &req); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	c.mEdges.Lock()
+	defer c.mEdges.Unlock()
+	c.edges[req.ID] = req
+
+	return req.ID, nil
+}
+
+// DeleteEdge deletes an edge by ID.
+func (c *Client) DeleteEdge(ctx context.Context, edgeID uuid.UUID) error {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	c.mEdges.Lock()
+	delete(c.edges, edgeID)
+	c.mEdges.Unlock()
+
+	return ucerr.Wrap(c.client.Delete(ctx, fmt.Sprintf("/authz/edges/%s", edgeID)))
+}

--- a/authz/constants.go
+++ b/authz/constants.go
@@ -1,0 +1,27 @@
+package authz
+
+import "github.com/gofrs/uuid"
+
+// AuthZ object types & edge types (roles) provisioned for every tenant.
+// TODO: merge the string constant with the UUID into a const-ish struct to keep them associated,
+// particularly if we add more of these.
+// Keep in sync with TSX constants!
+// TODO: we should have a better way to sync constants between TS and Go
+const (
+	GroupObjectType = "_group"
+	UserObjectType  = "_user"
+	AdminRole       = "_admin"
+	MemberRole      = "_member"
+)
+
+// UserObjectTypeID is the ID of a built-in object type called "_user"
+var UserObjectTypeID = uuid.Must(uuid.FromString("1bf2b775-e521-41d3-8b7e-78e89427e6fe"))
+
+// GroupObjectTypeID is the ID of a built-in object type called "_group"
+var GroupObjectTypeID = uuid.Must(uuid.FromString("f5bce640-f866-4464-af1a-9e7474c4a90c"))
+
+// AdminRoleTypeID is the ID of a built-in edge type called "_admin"
+var AdminRoleTypeID = uuid.Must(uuid.FromString("60b69666-4a8a-4eb3-94dd-621298fb365d"))
+
+// MemberRoleTypeID is the ID of a built-in edge type called "_member"
+var MemberRoleTypeID = uuid.Must(uuid.FromString("1eec16ec-6130-4f9e-a51f-21bc19b20d8f"))

--- a/authz/models.go
+++ b/authz/models.go
@@ -1,0 +1,99 @@
+package authz
+
+import (
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/ucdb"
+	"userclouds.com/infra/ucerr"
+)
+
+// ObjectType represents the type definition of an AuthZ object.
+type ObjectType struct {
+	ucdb.BaseModel
+
+	TypeName string `db:"type_name" json:"type_name"`
+}
+
+// Validate implements Validateable
+func (o ObjectType) Validate() error {
+	if o.TypeName == "" {
+		return ucerr.New("TypeName can't be empty")
+	}
+	return ucerr.Wrap(o.BaseModel.Validate())
+}
+
+// EdgeType defines a single, strongly-typed relationship
+// that a "source" object type can have to a "target" object type.
+type EdgeType struct {
+	ucdb.BaseModel
+
+	TypeName           string    `db:"type_name" json:"type_name"`
+	SourceObjectTypeID uuid.UUID `db:"source_object_type_id,immutable" json:"source_object_type_id"`
+	TargetObjectTypeID uuid.UUID `db:"target_object_type_id,immutable" json:"target_object_type_id"`
+}
+
+// Validate implements Validateable
+func (e EdgeType) Validate() error {
+	if e.TypeName == "" {
+		return ucerr.New("TypeName can't be empty")
+	}
+	if e.SourceObjectTypeID == uuid.Nil {
+		return ucerr.New("SourceObjectTypeID can't have nil ID")
+	}
+	if e.TargetObjectTypeID == uuid.Nil {
+		return ucerr.New("TargetObjectTypeID can't have nil ID")
+	}
+	return nil
+}
+
+// Object represents an instance of an AuthZ object used for modeling permissions.
+type Object struct {
+	ucdb.BaseModel
+
+	Alias  string    `db:"alias" json:"alias"`
+	TypeID uuid.UUID `db:"type_id,immutable" json:"type_id"`
+}
+
+// Validate implements Validateable
+func (o Object) Validate() error {
+	if o.Alias == "" {
+		return ucerr.New("Alias can't be empty")
+	}
+	if o.TypeID == uuid.Nil {
+		return ucerr.New("TypeID can't have nil ID")
+	}
+	return ucerr.Wrap(o.BaseModel.Validate())
+}
+
+// Edge represents a directional relationship between a "source"
+// object and a "target" object.
+type Edge struct {
+	ucdb.BaseModel
+
+	// This must be a valid EdgeType.ID value
+	EdgeTypeID uuid.UUID `db:"edge_type_id" json:"edge_type_id"`
+	// These must be valid ObjectType.ID values
+	SourceObjectID uuid.UUID `db:"source_object_id" json:"source_object_id"`
+	TargetObjectID uuid.UUID `db:"target_object_id" json:"target_object_id"`
+}
+
+// Validate implements Validateable
+func (o Edge) Validate() error {
+	if o.EdgeTypeID == uuid.Nil {
+		return ucerr.New("EdgeTypeID can't have nil ID")
+	}
+	if o.SourceObjectID == uuid.Nil {
+		return ucerr.New("SourceObjectID can't have nil ID")
+	}
+	if o.TargetObjectID == uuid.Nil {
+		return ucerr.New("TargetObjectID can't have nil ID")
+	}
+	return ucerr.Wrap(o.BaseModel.Validate())
+}
+
+// UserObject is a limited view of the `users` table used by the AuthZ service.
+// To avoid a dependency on IDP packages, AuthZ uses this stub structure to load a limited slice of User
+// objects for authz purposes instead of depending on `idp/internal/storage`.`
+type UserObject struct {
+	ucdb.BaseModel
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module userclouds.com
+
+go 1.16
+
+require (
+	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
+github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPh
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/idp/client.go
+++ b/idp/client.go
@@ -1,0 +1,456 @@
+package idp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/idp/userstore"
+	"userclouds.com/infra/emailutil"
+	"userclouds.com/infra/jsonclient"
+	"userclouds.com/infra/ucerr"
+)
+
+// AuthnType defines the kinds of authentication factors
+type AuthnType string
+
+// AuthnType constants
+const (
+	AuthnTypePassword AuthnType = "password"
+	AuthnTypeSocial   AuthnType = "social"
+
+	// Used for filter queries; not a valid type
+	AuthnTypeAll AuthnType = "all"
+)
+
+// Validate implements Validateable
+func (a AuthnType) Validate() error {
+	if a == AuthnTypePassword || a == AuthnTypeSocial || a == AuthnTypeAll {
+		return nil
+	}
+	return ucerr.Errorf("invalid AuthnType: %s", string(a))
+}
+
+// SocialProvider defines the known External/Social Identity Providers
+type SocialProvider int
+
+// SocialProvider constants
+const (
+	// When sync'ing data from other IDPs, it's possible to encounter social auth providers not yet supported,
+	// in which case we store SocialProviderUnsupported in the DB.
+	SocialProviderUnsupported SocialProvider = -1
+
+	// Not having a social provider is the "default", hence why SocialProviderNone is 0.
+	SocialProviderNone SocialProvider = 0
+
+	// Valid social auth providers are numbered starting with 1
+	SocialProviderGoogle SocialProvider = 1
+)
+
+//go:generate genconstant SocialProvider
+
+// Validate implements Validateable
+func (s SocialProvider) Validate() error {
+	// None and Unsupported are both "valid" for different scenarios (see documentation on constants)
+	if s == SocialProviderGoogle || s == SocialProviderNone || s == SocialProviderUnsupported {
+		return nil
+	}
+	return ucerr.Errorf("invalid SocialProvider: %s", s.String())
+}
+
+// UsernamePasswordLoginRequest specifies the IDP request to login with username & password.
+type UsernamePasswordLoginRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// LoginStatus indicates whether a login attempt succeeded, failed, or requires additional validation (e.g. MFA)
+type LoginStatus string
+
+// LoginStatus constants
+const (
+	LoginStatusSuccess     LoginStatus = "success"
+	LoginStatusMFARequired LoginStatus = "mfa_required"
+)
+
+// LoginResponse is the full response returned from an IDP login API
+type LoginResponse struct {
+	Status LoginStatus `json:"status"`
+
+	// UserID is set iff Status == LoginStatusSuccess (TODO: maybe also LoginStatusMFARequired?)
+	UserID uuid.UUID `json:"user_id"`
+
+	// MFAToken is set iff Status == LoginStatusMFARequired
+	MFAToken string `json:"mfa_token,omitempty"`
+}
+
+// UpdateUsernamePasswordRequest is used to keep the follower IDP(s) in sync
+type UpdateUsernamePasswordRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+// UpdateUsernamePasswordResponse confirms an update succeeded (or not)
+type UpdateUsernamePasswordResponse struct {
+	Success bool `json:"success"`
+}
+
+// MFALoginRequest allows the client to submit an MFA code
+type MFALoginRequest struct {
+	MFARequestID uuid.UUID
+	MFACode      string
+}
+
+// Client represents a client to talk to the Userclouds IDP
+type Client struct {
+	client *jsonclient.Client
+}
+
+// NewClient constructs a new IDP client
+func NewClient(url string, opts ...jsonclient.Option) (*Client, error) {
+	c := &Client{
+		client: jsonclient.New(strings.TrimSuffix(url, "/"), opts...),
+	}
+	if err := c.client.ValidateBearerTokenHeader(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+	return c, nil
+}
+
+// Login supports username/password login to the UC IDP
+func (c *Client) Login(ctx context.Context, username, password string) (*LoginResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	lr := UsernamePasswordLoginRequest{
+		Username: username,
+		Password: password,
+	}
+	var response LoginResponse
+
+	if err := c.client.Post(ctx, "/authn/uplogin", lr, &response, jsonclient.ParseOAuthError()); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return &response, nil
+}
+
+// LoginWithMFA sends the MFA code response
+func (c *Client) LoginWithMFA(ctx context.Context, sessionID, code string) (*LoginResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	id, err := uuid.FromString(sessionID)
+	if err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	body := MFALoginRequest{id, code}
+	var response LoginResponse
+	if err := c.client.Post(ctx, "/authn/mfaresponse", body, &response, jsonclient.ParseOAuthError()); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return &response, nil
+}
+
+// UpdateUsernamePassword updates the stored password for a user for follower-sync purposes
+func (c *Client) UpdateUsernamePassword(ctx context.Context, username, password string) error {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	lr := UpdateUsernamePasswordRequest{
+		Username: username,
+		Password: password,
+	}
+
+	var response UpdateUsernamePasswordResponse
+	if err := c.client.Post(ctx, "/authn/upupdate", lr, &response); err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	if !response.Success {
+		return ucerr.New("update username/password failure")
+	}
+
+	return nil
+}
+
+// UserAuthn represents an authentication factor for a user.
+// NOTE: some fields are not used in some circumstances, e.g. Password is only
+// used when creating an account but never used when getting an account.
+// TODO: use this for UpdateUser too.
+type UserAuthn struct {
+	AuthnType AuthnType `json:"authn_type"`
+
+	// Fields specified if AuthnType == 'password'
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+
+	// Fields specified if AuthnType == 'social'
+	SocialProvider SocialProvider `json:"social_provider,omitempty"`
+	OIDCSubject    string         `json:"oidc_subject,omitempty"`
+}
+
+// NewPasswordAuthn creates a new UserAuthn for username + password.
+func NewPasswordAuthn(username, password string) UserAuthn {
+	return UserAuthn{
+		AuthnType: AuthnTypePassword,
+		Username:  username,
+		Password:  password,
+	}
+}
+
+// NewSocialAuthn creates a new UserAuthn for social / OIDC login.
+func NewSocialAuthn(provider SocialProvider, oidcSubject string) UserAuthn {
+	return UserAuthn{
+		AuthnType:      AuthnTypeSocial,
+		SocialProvider: provider,
+		OIDCSubject:    oidcSubject,
+	}
+}
+
+// UserProfile is a collection of per-user properties stored in the DB as JSON since
+// they are likely to be sparse and change more frequently.
+// Follow conventions of https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims for
+// all standard fields.
+type UserProfile struct {
+	Email         string `json:"email" validate:"notempty"`
+	EmailVerified bool   `json:"email_verified"`
+	Name          string `json:"name,omitempty"`     // Full name in displayable form (incl titles, suffixes, etc) localized to end-user.
+	Nickname      string `json:"nickname,omitempty"` // Casual name of the user, may or may not be same as Given Name.
+	Picture       string `json:"picture,omitempty"`  // URL of the user's profile picture.
+
+	// TODO: email is tricky; it's used for authn, 2fa, and (arguably) user profile.
+	// If a user merges authns (e.g. I had 2 accounts, oops), then there can be > 1.
+	// It may make sense to keep the primary user email (used for 2FA) in `User`, separately
+	// from the profile, but allow 0+ profile emails (e.g. alternate contacts, merged accounts, etc).
+}
+
+//go:generate gendbjson UserProfile
+
+//go:generate genvalidate UserProfile
+
+func (u UserProfile) extraValidate() error {
+	if err := emailutil.Validate(u.Email); err != nil {
+		return ucerr.Wrap(err)
+	}
+	return nil
+}
+
+// CreateUserRequest creates a user on the IDP
+type CreateUserRequest struct {
+	UserProfile `json:"profile"`
+
+	RequireMFA bool `json:"require_mfa"`
+
+	UserExtendedProfile userstore.Record `json:"profile_ext"`
+
+	UserAuthn
+}
+
+// UserResponse is the response body for methods which return user data.
+type UserResponse struct {
+	ID        uuid.UUID `json:"id"`
+	UpdatedAt int64     `json:"updated_at"` // seconds since the Unix Epoch (UTC)
+
+	UserProfile `json:"profile"`
+
+	RequireMFA bool `json:"require_mfa"`
+
+	UserExtendedProfile userstore.Record `json:"profile_ext"`
+
+	Authns []UserAuthn `json:"authns"`
+}
+
+// CreateUserWithPassword creates a user on the IDP
+func (c *Client) CreateUserWithPassword(ctx context.Context, username, password string, profile UserProfile) (uuid.UUID, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	if err := profile.Validate(); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	req := CreateUserRequest{
+		UserProfile: profile,
+		RequireMFA:  false,
+		UserAuthn:   NewPasswordAuthn(username, password),
+	}
+
+	var res UserResponse
+
+	if err := c.client.Post(ctx, "/authn/users", req, &res); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	return res.ID, nil
+}
+
+// CreateUserWithSocial creates a user on the IDP
+func (c *Client) CreateUserWithSocial(ctx context.Context, provider SocialProvider, subject string, profile UserProfile) (uuid.UUID, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	req := CreateUserRequest{
+		UserProfile: profile,
+		RequireMFA:  false,
+		UserAuthn:   NewSocialAuthn(provider, subject),
+	}
+
+	var res UserResponse
+
+	if err := c.client.Post(ctx, "/authn/users", req, &res); err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+
+	return res.ID, nil
+}
+
+// ListUsers lists all users
+// TODO: pagination desperately needed
+func (c *Client) ListUsers(ctx context.Context) ([]UserResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var res []UserResponse
+
+	requestURL := url.URL{Path: "/authn/users"}
+
+	if err := c.client.Get(ctx, requestURL.String(), &res); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return res, nil
+}
+
+// GetUser gets a user by ID
+func (c *Client) GetUser(ctx context.Context, id uuid.UUID) (*UserResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var res UserResponse
+
+	requestURL := url.URL{
+		Path: fmt.Sprintf("/authn/users/%s", id),
+	}
+
+	if err := c.client.Get(ctx, requestURL.String(), &res); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return &res, nil
+}
+
+// GetUserForSocial gets a user by social provider / ID
+func (c *Client) GetUserForSocial(ctx context.Context, provider SocialProvider, oidcSubject string) (*UserResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var res []UserResponse
+
+	prov, err := provider.MarshalText()
+	if err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+	reqURL := url.URL{
+		Path: "/authn/users",
+		RawQuery: url.Values{
+			"authn_type": []string{string(AuthnTypeSocial)},
+			"provider":   []string{string(prov)},
+			"subject":    []string{oidcSubject},
+		}.Encode(),
+	}
+	if err := c.client.Get(ctx, reqURL.String(), &res); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	if len(res) != 1 {
+		return nil, ucerr.Errorf("unexpected number of results (%d)", len(res))
+	}
+
+	return &res[0], nil
+}
+
+// ListUsersForEmail gets all user accounts associated with an email and authn type
+func (c *Client) ListUsersForEmail(ctx context.Context, email string, authnType AuthnType) ([]UserResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	var res []UserResponse
+
+	requestURL := url.URL{
+		Path: "/authn/users",
+		RawQuery: url.Values{
+			"email":      []string{email},
+			"authn_type": []string{string(authnType)},
+		}.Encode(),
+	}
+
+	if err := c.client.Get(ctx, requestURL.String(), &res); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return res, nil
+}
+
+// UpdateUserRequest optionally updates some or all mutable fields of a user struct.
+// Pointers are used to distinguish between unset vs. set to default value (false, "", etc).
+// TODO: should we allow changing Email? That's a more complex one as there are more implications to
+// changing email that may affect AuthNs and security (e.g. account hijacking, unverified emails, etc).
+type UpdateUserRequest struct {
+	EmailVerified *bool   `json:"email_verified,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	Nickname      *string `json:"nickname,omitempty"`
+	Picture       *string `json:"picture,omitempty"`
+
+	// TODO: add MFA factors
+	RequireMFA *bool `json:"require_mfa,omitempty"`
+
+	// Only fields set in the underlying map will be updated
+	UserExtendedProfile userstore.Record `json:"profile_ext"`
+}
+
+// UpdateUser updates user profile data for a given user ID
+func (c *Client) UpdateUser(ctx context.Context, id uuid.UUID, req UpdateUserRequest) (*UserResponse, error) {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	requestURL := url.URL{
+		Path: fmt.Sprintf("/authn/users/%s", id),
+	}
+
+	var resp UserResponse
+
+	if err := c.client.Put(ctx, requestURL.String(), &req, &resp); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return &resp, nil
+}
+
+// DeleteUser deletes a user by ID
+func (c *Client) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	if err := c.client.RefreshBearerToken(); err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	requestURL := url.URL{
+		Path: fmt.Sprintf("/authn/users/%s", id),
+	}
+
+	return ucerr.Wrap(c.client.Delete(ctx, requestURL.String()))
+}

--- a/idp/socialprovider_constant_generated.go
+++ b/idp/socialprovider_constant_generated.go
@@ -1,0 +1,44 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package idp
+
+import "userclouds.com/infra/ucerr"
+
+// MarshalText implements encoding.TextMarshaler (for JSON)
+func (t SocialProvider) MarshalText() ([]byte, error) {
+	switch t {
+	case SocialProviderGoogle:
+		return []byte("google"), nil
+	case SocialProviderNone:
+		return []byte("none"), nil
+	case SocialProviderUnsupported:
+		return []byte("unsupported"), nil
+	default:
+		return nil, ucerr.Errorf("unknown value %d", t)
+	}
+}
+
+// UnmarshalText implements encoding.TextMarshaler (for JSON)
+func (t *SocialProvider) UnmarshalText(b []byte) error {
+	s := string(b)
+	switch s {
+	case "google":
+		*t = SocialProviderGoogle
+	case "none":
+		*t = SocialProviderNone
+	case "unsupported":
+		*t = SocialProviderUnsupported
+	default:
+		return ucerr.Errorf("unknown value %s", s)
+	}
+	return nil
+}
+
+// just here for easier debugging
+func (t SocialProvider) String() string {
+	bs, err := t.MarshalText()
+	if err != nil {
+		return err.Error()
+	}
+	return string(bs)
+}

--- a/idp/userprofile_validate_generated.go
+++ b/idp/userprofile_validate_generated.go
@@ -1,0 +1,19 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package idp
+
+import (
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate implements Validateable
+func (o *UserProfile) Validate() error {
+	// .extraValidate() lets you do any validation you can't express in codegen tags yet
+	if err := o.extraValidate(); err != nil {
+		return ucerr.Wrap(err)
+	}
+	if o.Email == "" {
+		return ucerr.Errorf("UserProfile.Email can't be empty")
+	}
+	return nil
+}

--- a/idp/userstore/fieldtype_constant_generated.go
+++ b/idp/userstore/fieldtype_constant_generated.go
@@ -1,0 +1,44 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package userstore
+
+import "userclouds.com/infra/ucerr"
+
+// MarshalText implements encoding.TextMarshaler (for JSON)
+func (t FieldType) MarshalText() ([]byte, error) {
+	switch t {
+	case FieldTypeInvalid:
+		return []byte("invalid"), nil
+	case FieldTypeString:
+		return []byte("string"), nil
+	case FieldTypeTimestamp:
+		return []byte("timestamp"), nil
+	default:
+		return nil, ucerr.Errorf("unknown value %d", t)
+	}
+}
+
+// UnmarshalText implements encoding.TextMarshaler (for JSON)
+func (t *FieldType) UnmarshalText(b []byte) error {
+	s := string(b)
+	switch s {
+	case "invalid":
+		*t = FieldTypeInvalid
+	case "string":
+		*t = FieldTypeString
+	case "timestamp":
+		*t = FieldTypeTimestamp
+	default:
+		return ucerr.Errorf("unknown value %s", s)
+	}
+	return nil
+}
+
+// just here for easier debugging
+func (t FieldType) String() string {
+	bs, err := t.MarshalText()
+	if err != nil {
+		return err.Error()
+	}
+	return string(bs)
+}

--- a/idp/userstore/schema.go
+++ b/idp/userstore/schema.go
@@ -1,0 +1,117 @@
+package userstore
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// Schema defines the format of the User Data Store/Vault for a given tenant.
+type Schema struct {
+	Fields []Field `json:"fields"`
+}
+
+//go:generate gendbjson Schema
+
+//go:generate genvalidate Schema
+
+// FieldType is an enum for supported field types
+type FieldType int
+
+// FieldType constants (leaving gaps intentionally to allow future related types to be grouped)
+// NOTE: keep in sync with mapFieldType defined in TenantUserStoreConfig.tsx
+const (
+	FieldTypeInvalid FieldType = 0
+
+	FieldTypeString FieldType = 100
+
+	FieldTypeTimestamp FieldType = 200
+)
+
+//go:generate genconstant FieldType
+
+// Validate implements Validateable
+func (ft FieldType) Validate() error {
+	switch ft {
+	case FieldTypeString:
+		fallthrough
+	case FieldTypeTimestamp:
+		return nil
+	}
+	return ucerr.Errorf("invalid FieldType: %s", ft.String())
+}
+
+// Field represents a single field/column/value to be collected/stored/managed
+// in the user data store of a tenant.
+type Field struct {
+	// Fields may be renamed, but their ID cannot be changed.
+	ID   uuid.UUID `json:"id" validate:"notnil"`
+	Name string    `json:"name" validate:"notempty"`
+	Type FieldType `json:"type"`
+}
+
+//go:generate genvalidate Field
+
+// Record is a single "row" of data containing 0 or more Fields that adhere to a Schema.
+// The key is the Field UUID, since names can change but IDs are stable.
+type Record map[uuid.UUID]interface{}
+
+//go:generate gendbjson Record
+
+func getFieldType(i interface{}) FieldType {
+	switch i.(type) {
+	case string:
+		return FieldTypeString
+	case time.Time:
+		return FieldTypeTimestamp
+	default:
+		return FieldTypeInvalid
+	}
+}
+
+// Validate implements Validateable and ensures that a Record has fields
+// which consist only of valid Field Types.
+// TODO: need a Validation method that validates against a particular schema.
+func (r Record) Validate() error {
+	for k, i := range r {
+		if t := getFieldType(i); t == FieldTypeInvalid {
+			return ucerr.Errorf("unknown type for Record[%s]: %T", k, i)
+		}
+	}
+	return nil
+}
+
+// FixupAndValidate validates a record against a schema, and fixes up types in the record
+// to match the schema when possible (e.g. since JSON and other serde formats don't preserve Go types,
+// this attempts to parse rich types from strings as needed).
+// This method should be called whenever a Record is deserialized.
+func (r Record) FixupAndValidate(s *Schema) error {
+	for k, i := range r {
+		var field *Field
+		for idx := range s.Fields {
+			if k == s.Fields[idx].ID {
+				field = &s.Fields[idx]
+				break
+			}
+		}
+		if field == nil {
+			return ucerr.Errorf("no Field in Schema with matching ID for Record[%s]", k)
+		}
+		actualType := getFieldType(i)
+		// In JSON, times get [de-]serialized to/from strings, so we need to handle special types.
+		// Other future types will need similar conversion (e.g. lat/long, phone numbers, etc)
+		if field.Type == FieldTypeTimestamp && actualType == FieldTypeString {
+			t, err := time.Parse(time.RFC3339, i.(string))
+			if err == nil {
+				r[k] = t
+				actualType = getFieldType(r[k])
+			}
+		}
+		if actualType != field.Type {
+			return ucerr.Errorf("expected Record[%s] to have type %s, got %s instead", k, field.Type, actualType)
+		}
+	}
+	return nil
+}

--- a/infra/emailutil/validate.go
+++ b/infra/emailutil/validate.go
@@ -1,0 +1,26 @@
+package emailutil
+
+import (
+	"net/mail"
+	"unicode"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate returns an error if the provided email string is invalid, or nil if it's valid.
+func Validate(email string) error {
+	if _, err := mail.ParseAddress(email); err != nil {
+		return ucerr.Errorf("invalid email: %w", err)
+	}
+
+	// Golang's email parser allows for things like
+	// "My Name <foo@contoso.com>" which we don't allow, so also disallow whitespace.
+	for _, v := range email {
+		// Test each character to see if it is whitespace.
+		if unicode.IsSpace(v) {
+			return ucerr.New("invalid email: no whitespace allowed")
+		}
+	}
+
+	return nil
+}

--- a/infra/jsonclient/bearer.go
+++ b/infra/jsonclient/bearer.go
@@ -1,0 +1,26 @@
+package jsonclient
+
+import (
+	"net/http"
+	"strings"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// ExtractBearerToken extracts a bearer token from an HTTP request or returns an error
+// if none is found or if it's malformed.
+// NOTE: this doesn't enforce that it's a JWT, much less a valid one.
+func ExtractBearerToken(h *http.Header) (string, error) {
+	bearerToken := h.Get("Authorization")
+	if bearerToken == "" {
+		return "", ucerr.New("authorization header required")
+	}
+
+	const bearerPrefix = "Bearer "
+	if !strings.HasPrefix(bearerToken, bearerPrefix) {
+		return "", ucerr.New("authorization header requires bearer token")
+	}
+
+	bearerToken = strings.TrimPrefix(bearerToken, bearerPrefix)
+	return bearerToken, nil
+}

--- a/infra/jsonclient/client.go
+++ b/infra/jsonclient/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -289,7 +288,8 @@ func (c *Client) makeRequest(ctx context.Context, method, path string, bs []byte
 		} else {
 			bs = string(b)
 		}
-		log.Printf("http %s request to URL '%s' returned error response (code %d): %s", method, reqURL, res.StatusCode, bs) // ucwrapper-safe - avoid uclog dependency since this is used by SDK
+		// Use a package-internal method to log so we can diverge behavior between private vs public repos easily
+		logError(ctx, method, reqURL, bs, res.StatusCode)
 
 		if options.parseOAuthError {
 			var oauthe ucerr.OAuthError

--- a/infra/jsonclient/client.go
+++ b/infra/jsonclient/client.go
@@ -1,0 +1,334 @@
+package jsonclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"userclouds.com/infra/oidc"
+	"userclouds.com/infra/ucerr"
+	"userclouds.com/infra/ucjwt"
+)
+
+// Error defines a jsonclient error for non-2XX/3XX status codes
+// TODO: decide how to handle 3XX results
+type Error struct {
+	StatusCode int
+}
+
+// Error implements Error
+func (e Error) Error() string {
+	return fmt.Sprintf("HTTP error %d", e.StatusCode)
+}
+
+type options struct {
+	headers          http.Header
+	cookies          []http.Cookie
+	unmarshalOnError bool
+	parseOAuthError  bool
+
+	// Required for automatic token refresh
+	tokenSource oidc.ClientCredentialsTokenSource
+}
+
+func (o *options) clone() *options {
+	cloned := *o
+	cloned.headers = o.headers.Clone()
+	copy(cloned.cookies, o.cookies)
+	return &cloned
+}
+
+// Option makes jsonclient extensible
+type Option interface {
+	apply(*options)
+}
+
+type optFunc func(*options)
+
+func (o optFunc) apply(opts *options) {
+	o(opts)
+}
+
+// Header allows you to add arbitrary headers to jsonclient requests
+func Header(k, v string) Option {
+	return optFunc(func(opts *options) {
+		opts.headers.Set(k, v)
+	})
+}
+
+// Cookie allows you to add cookies to jsonclient requests
+func Cookie(cookie http.Cookie) Option {
+	return optFunc(func(opts *options) {
+		opts.cookies = append(opts.cookies, cookie)
+	})
+}
+
+// UnmarshalOnError causes the response struct to be deserialized if a HTTP 400+ code is returned.
+// The default behavior is to not deserialize and to return an error.
+func UnmarshalOnError() Option {
+	return optFunc(func(opts *options) {
+		opts.unmarshalOnError = true
+	})
+}
+
+// ParseOAuthError allows deserializing & capturing the last call's error
+// into an OAuthError object for deeper inspection. This is richer than a jsonclient.Error
+// but only makes sense on a call that is expected to be OAuth/OIDC compliant.
+func ParseOAuthError() Option {
+	return optFunc(func(opts *options) {
+		opts.parseOAuthError = true
+	})
+}
+
+// ClientCredentialsTokenSource can be specified to enable support for RefreshBearerToken automatically
+// refreshing the token if expired.
+func ClientCredentialsTokenSource(tokenURL, clientID, clientSecret string, customAudiences []string) Option {
+	return optFunc(func(opts *options) {
+		opts.tokenSource.TokenURL = tokenURL
+		opts.tokenSource.ClientID = clientID
+		opts.tokenSource.ClientSecret = clientSecret
+		opts.tokenSource.CustomAudiences = customAudiences
+	})
+}
+
+// Client defines a JSON-focused HTTP client
+// TODO: someday this should use a custom http.Client etc
+type Client struct {
+	baseURL string
+
+	// Keep options contained so they can be cloned & augmented per request.
+	options      options
+	optionsMutex sync.RWMutex
+}
+
+// New returns a new Client
+func New(url string, opts ...Option) *Client {
+	c := &Client{
+		baseURL: url,
+		options: options{
+			headers: make(http.Header),
+		},
+	}
+
+	for _, opt := range opts {
+		opt.apply(&c.options)
+	}
+
+	return c
+}
+
+// Apply applies options to an existing client (useful for updating a header/cookie/etc on an existing client).
+func (c *Client) Apply(opts ...Option) {
+	c.optionsMutex.Lock()
+	defer c.optionsMutex.Unlock()
+	for _, opt := range opts {
+		opt.apply(&c.options)
+	}
+}
+
+// GetBearerToken returns the bearer token associated with this client, if one exists,
+// or an error otherwise.
+func (c *Client) GetBearerToken() (string, error) {
+	c.optionsMutex.RLock()
+	defer c.optionsMutex.RUnlock()
+	token, err := ucjwt.ExtractBearerToken(&c.options.headers)
+	return token, ucerr.Wrap(err)
+}
+
+func (c *Client) tokenNeedsRefresh() bool {
+	needsRefresh := true
+	currentToken, err := c.GetBearerToken()
+	if err == nil {
+		needsRefresh, err = ucjwt.IsExpired(currentToken)
+		if err != nil {
+			needsRefresh = true
+		}
+	}
+	return needsRefresh
+}
+
+func (c *Client) hasTokenSource() bool {
+	c.optionsMutex.RLock()
+	defer c.optionsMutex.RUnlock()
+	return c.options.tokenSource.TokenURL != ""
+}
+
+// ValidateBearerTokenHeader ensures that there is a non-expired bearer token specified directly OR
+// that there's a valid token source to refresh it if not specified or expired.
+func (c *Client) ValidateBearerTokenHeader() error {
+	if c.tokenNeedsRefresh() && !c.hasTokenSource() {
+		return ucerr.New("cannot refresh unspecified or expired bearer token without specifying valid ClientCredentialsTokenSource option for jsonclient")
+	}
+	return nil
+}
+
+// RefreshBearerToken checks if the current token is invalid or expired, and refreshes it via
+// the Client Credentials Flow if needed.
+func (c *Client) RefreshBearerToken() error {
+	if c.tokenNeedsRefresh() {
+		if !c.hasTokenSource() {
+			return ucerr.New("cannot refresh bearer token without specifying valid ClientCredentialsTokenSource option for jsonclient")
+		}
+
+		c.optionsMutex.RLock()
+		accessToken, err := c.options.tokenSource.GetToken()
+		c.optionsMutex.RUnlock()
+		if err != nil {
+			return ucerr.Wrap(err)
+		}
+
+		c.Apply(Header("Authorization", fmt.Sprintf("Bearer %s", accessToken)))
+	}
+	return nil
+}
+
+// Get makes an HTTP get using this client
+// TODO: need to support query params soon :)
+func (c *Client) Get(ctx context.Context, path string, response interface{}, opts ...Option) error {
+	return ucerr.Wrap(c.makeRequest(ctx, http.MethodGet, path, nil, response, opts))
+}
+
+// Post makes an HTTP post using this client
+// If response is nil, the response isn't decoded and merely the success or failure is returned
+func (c *Client) Post(ctx context.Context, path string, body, response interface{}, opts ...Option) error {
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	return ucerr.Wrap(c.makeRequest(ctx, http.MethodPost, path, bs, response, opts))
+}
+
+// Put makes an HTTP put using this client
+// If response is nil, the response isn't decoded and merely the success or failure is returned
+func (c *Client) Put(ctx context.Context, path string, body, response interface{}, opts ...Option) error {
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	return ucerr.Wrap(c.makeRequest(ctx, http.MethodPut, path, bs, response, opts))
+}
+
+// Patch makes an HTTP patch using this client
+// If response is nil, the response isn't decoded and merely the success or failure is returned
+func (c *Client) Patch(ctx context.Context, path string, body, response interface{}, opts ...Option) error {
+	bs, err := json.Marshal(body)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	return ucerr.Wrap(c.makeRequest(ctx, http.MethodPatch, path, bs, response, opts))
+}
+
+// Delete makes an HTTP delete using this client
+func (c *Client) Delete(ctx context.Context, path string, opts ...Option) error {
+	return ucerr.Wrap(c.makeRequest(ctx, http.MethodDelete, path, nil, nil, opts))
+}
+
+func (c *Client) makeRequest(ctx context.Context, method, path string, bs []byte, response interface{}, opts []Option) error {
+	// Always clone to minimize contention
+	c.optionsMutex.RLock()
+	options := c.options.clone()
+	c.optionsMutex.RUnlock()
+
+	// Concat per-request options
+	for _, opt := range opts {
+		opt.apply(options)
+	}
+	client := http.DefaultClient
+
+	reqURL := c.buildURL(path)
+	req, err := http.NewRequest(method, reqURL, bytes.NewReader(bs))
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	req.Header = options.headers.Clone()
+	req.Header.Add("content-type", "application/json")
+
+	for _, cookie := range options.cookies {
+		req.AddCookie(&cookie)
+	}
+
+	// https://github.com/golang/go/issues/29865
+	// Host header is ignored by http.Request.Write, but for test purposes
+	// it is very useful to override the Host header.
+	if req.Header.Get("Host") != "" {
+		req.Host = req.Header.Get("Host")
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+	defer res.Body.Close()
+
+	// If the response was not an error OR if the caller specified UnmarshalOnError, try to deserialize
+	// the response into the provided struct.
+	if res.StatusCode < http.StatusBadRequest || options.unmarshalOnError {
+		if response != nil {
+			if err := json.NewDecoder(res.Body).Decode(response); err != nil {
+				return ucerr.Wrap(err)
+			}
+		}
+	} else {
+		// An error was returned and the caller is not intentionally capturing the body; log full error response for debugging purposes.
+		// TODO: hide behind a flag for perf / PII / etc reasons?
+		b, err := io.ReadAll(res.Body)
+		var bs string
+		if err != nil {
+			bs = "<unable to decode response>"
+		} else {
+			bs = string(b)
+		}
+		log.Printf("http %s request to URL '%s' returned error response (code %d): %s", method, reqURL, res.StatusCode, bs) // ucwrapper-safe - avoid uclog dependency since this is used by SDK
+
+		if options.parseOAuthError {
+			var oauthe ucerr.OAuthError
+			// OAuth standard requires us to return a body with error descriptions
+			// in many cases, so try to decode response but ignore the error if it fails.
+			err = json.NewDecoder(bytes.NewReader(b)).Decode(&oauthe)
+			if err == nil {
+				// Ensure we use the actual code from the http response.
+				oauthe.Code = res.StatusCode
+				return ucerr.Wrap(oauthe)
+			}
+		}
+	}
+
+	// TODO: validate that 2xx is received, not 3xx or something else?
+
+	if res.StatusCode >= http.StatusBadRequest {
+		return ucerr.Wrap(Error{res.StatusCode})
+	}
+
+	return nil
+}
+
+// normalize trailing and leading slashes
+func (c *Client) buildURL(path string) string {
+	if path != "" {
+		return fmt.Sprintf("%s/%s", strings.TrimSuffix(c.baseURL, "/"), strings.TrimPrefix(path, "/"))
+	}
+	return c.baseURL
+}
+
+// GetHTTPStatusCode returns the underlying HTTP status code or -1 if no code could be extracted.
+func GetHTTPStatusCode(err error) int {
+	var jce Error
+	var oauthe ucerr.OAuthError
+	if errors.As(err, &jce) {
+		return jce.StatusCode
+	} else if errors.As(err, &oauthe) {
+		return oauthe.Code
+	}
+	return -1
+}

--- a/infra/jsonclient/log.go
+++ b/infra/jsonclient/log.go
@@ -1,0 +1,7 @@
+package jsonclient
+
+import "context"
+
+func logError(ctx context.Context, method, url, errorMsg string, code int) {
+	// don't log by default in SDK
+}

--- a/infra/oidc/clientcredentials.go
+++ b/infra/oidc/clientcredentials.go
@@ -1,0 +1,54 @@
+package oidc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// ClientCredentialsTokenSource encapsulates parameters required to issue a Client Credentials OIDC request and return a token
+type ClientCredentialsTokenSource struct {
+	TokenURL        string
+	ClientID        string
+	ClientSecret    string
+	CustomAudiences []string
+}
+
+// GetToken issues a request to an OIDC-compliant token endpoint to perform
+// the Client Credentials flow in exchange for an access token.
+func (ccts ClientCredentialsTokenSource) GetToken() (string, error) {
+	query := url.Values{}
+	// TODO: move common OIDC values into constants
+	query.Add("grant_type", "client_credentials")
+	query.Add("client_id", ccts.ClientID)
+	query.Add("client_secret", ccts.ClientSecret)
+	for _, aud := range ccts.CustomAudiences {
+		query.Add("audience", aud)
+	}
+	req, err := http.NewRequest(http.MethodPost, ccts.TokenURL, strings.NewReader(query.Encode()))
+	if err != nil {
+		return "", ucerr.Wrap(err)
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	// TODO: re-use client?
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", ucerr.Wrap(err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		var oauthe ucerr.OAuthError
+		if err := json.NewDecoder(resp.Body).Decode(&oauthe); err != nil {
+			return "", ucerr.Wrap(err)
+		}
+		oauthe.Code = resp.StatusCode
+		return "", ucerr.Wrap(oauthe)
+	}
+	var tresp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tresp); err != nil {
+		return "", ucerr.Wrap(err)
+	}
+	return tresp.AccessToken, nil
+}

--- a/infra/oidc/token.go
+++ b/infra/oidc/token.go
@@ -1,0 +1,72 @@
+package oidc
+
+import (
+	"github.com/golang-jwt/jwt"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// StandardClaims is forked from golang-jwt/jwt.StandardClaims,
+// except Audience is an array here per the actual spec:
+//   In the general case, the "aud" value is an array of case-sensitive strings, each containing
+//   a StringOrURI value.  In the special case when the JWT has one audience, the "aud" value MAY
+//   be a single case-sensitive string containing a StringOrURI value.  The interpretation of
+//   audience values is generally application specific. Use of this claim is OPTIONAL.
+// https://tools.ietf.org/html/rfc7519#section-4.1
+type StandardClaims struct {
+	Audience  []string `json:"aud,omitempty"`
+	ExpiresAt int64    `json:"exp,omitempty"`
+	ID        string   `json:"jti,omitempty"`
+	IssuedAt  int64    `json:"iat,omitempty"`
+	Issuer    string   `json:"iss,omitempty"`
+	NotBefore int64    `json:"nbf,omitempty"`
+	Subject   string   `json:"sub,omitempty"`
+}
+
+// Valid implements jwt.Claims interface
+func (c StandardClaims) Valid() error {
+	// Use the time validation logic from jwt.StandardClaims
+	jwtClaims := jwt.StandardClaims{
+		ExpiresAt: c.ExpiresAt,
+		IssuedAt:  c.IssuedAt,
+		NotBefore: c.NotBefore,
+	}
+	return ucerr.Wrap(jwtClaims.Valid())
+}
+
+// TokenClaims represents the claims made by a token, and is also used by the UserInfo
+// endpoint to return standard OIDC user claims.
+type TokenClaims struct {
+	Name          string `json:"name,omitempty"`
+	Nickname      string `json:"nickname,omitempty"`
+	Email         string `json:"email,omitempty"`
+	EmailVerified bool   `json:"email_verified"`
+	Picture       string `json:"picture,omitempty"`
+	Nonce         string `json:"nonce,omitempty"`
+	UpdatedAt     int64  `json:"updated_at,omitempty"` // NOTE: Auth0 treats this as a string, but OIDC says this is seconds since the Unix Epoch
+	StandardClaims
+
+	// TODO: not sure if this is the right place for this, but didn't come up with a clever interface
+	// to use with GeneratePlexUserToken etc yet. With omitempty, it shouldn't affect anything else when unused
+	ImpersonatedBy string `json:"impersonated_by,omitempty"`
+}
+
+// Valid implements jwt.Claims interface
+func (t TokenClaims) Valid() error {
+	return ucerr.Wrap(t.StandardClaims.Valid())
+}
+
+// TokenResponse is an OIDC-compliant response from a token endpoint.
+// (either token exchange or resource owner password credential flow).
+// See https://datatracker.ietf.org/doc/html/rfc6749#section-5.1.
+// ErrorType will be non-empty if error.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int    `json:"expires_in,omitempty"`
+	IDToken      string `json:"id_token,omitempty"`
+
+	ErrorType string `json:"error,omitempty"`
+	ErrorDesc string `json:"error_description,omitempty"`
+}

--- a/infra/ucdb/basemodel.go
+++ b/infra/ucdb/basemodel.go
@@ -1,0 +1,68 @@
+package ucdb
+
+import (
+	"time"
+
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// BaseModel underlies (almost) all of our models
+type BaseModel struct {
+	ID uuid.UUID `db:"id" json:"id" yaml:"id"`
+
+	Created time.Time `db:"created" json:"created" yaml:"created"`
+	Updated time.Time `db:"updated" json:"updated" yaml:"updated"`
+
+	Deleted time.Time `db:"deleted" json:"deleted" yaml:"deleted"`
+}
+
+// Validate implements Validateable
+func (b BaseModel) Validate() error {
+	if b.ID == uuid.Nil {
+		return ucerr.New("UCBase can't have nil ID")
+	}
+	if b.Updated.IsZero() && !b.Alive() {
+		return ucerr.Errorf("%v was soft-deleted before it was ever saved", b.ID)
+	}
+	return nil
+}
+
+// Alive returns true if the object is "alive" and false if it's been deleted
+func (b BaseModel) Alive() bool {
+	return b.Deleted.IsZero()
+}
+
+// NewBase initializes a new UCBase
+func NewBase() BaseModel {
+	// note that we don't propogate NewV4() errors because at that point the world has ended.
+	return BaseModel{ID: uuid.Must(uuid.NewV4()), Deleted: time.Time{}} // lint: basemodel-safe
+}
+
+// NewBaseWithID initializes a new BaseModel with a specific ID
+func NewBaseWithID(id uuid.UUID) BaseModel {
+	b := NewBase()
+	b.ID = id
+	return b
+}
+
+// UserBaseModel is a user-related underlying model for many of our models eg. in IDP
+type UserBaseModel struct {
+	BaseModel
+
+	UserID uuid.UUID `db:"user_id" json:"user_id" yaml:"user_id"`
+}
+
+// Validate implements Validateable
+func (u UserBaseModel) Validate() error {
+	if u.UserID == uuid.Nil {
+		return ucerr.Errorf("UserBaseModel %v can't have nil UserID", u.ID)
+	}
+	return ucerr.Wrap(u.BaseModel.Validate())
+}
+
+// NewUserBase initializes a new user base model
+func NewUserBase(userID uuid.UUID) UserBaseModel {
+	return UserBaseModel{BaseModel: NewBase(), UserID: userID}
+}

--- a/infra/ucerr/error.go
+++ b/infra/ucerr/error.go
@@ -1,0 +1,152 @@
+package ucerr
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// UCError lets us figure out if this is a wrapped error
+type UCError interface {
+	BaseError() string
+	Error() string // include this so UCError implements Error for erroras linter
+}
+
+type ucError struct {
+	text       string
+	underlying error
+
+	function string
+	filename string
+	line     int
+}
+
+var errorWrappingSuffix = ": %w"
+var wrappedText = "(wrapped)"
+
+const repoRoot = "userclouds/"
+
+// Return a path relative to the repo root, assuming that:
+// (1) there is no 'userclouds' directory created within the source tree of our repo,
+// (2) the repo is cloned into the default directory.
+// If the path is not within the repo, return the path unmodified.
+func repoRelativePath(s string) string {
+	if idx := strings.LastIndex(s, repoRoot); idx >= 0 {
+		return s[idx+len(repoRoot):]
+	}
+	return s
+}
+
+// Given a fully qualified go function name "pkgname.[type].func",
+// return "func" (or return string unchanged if no period found).
+func funcName(s string) string {
+	if idx := strings.LastIndex(s, "."); idx >= 0 {
+		return s[idx+1:]
+	}
+	return s
+}
+
+// BaseError implements UCError
+// Just return the error message(s), no stack trace
+func (e ucError) BaseError() string {
+	var msg string
+	// how do we wrap what's underlying us?
+	// 1) keep unwrapping until we're at the bottom of the wrapped stack
+	// 2) start with the error message from the original error
+	var uce UCError
+	if errors.As(e.underlying, &uce) {
+		msg = uce.BaseError()
+	} else if e.underlying != nil {
+		msg = e.underlying.Error()
+	}
+
+	// how do we display ourselves rationally?
+	// 3) if the bottom of the stack is just wrapping a non-UCError, don't show (wrapped)
+	t := e.text
+	if t == wrappedText {
+		t = ""
+	}
+
+	// is there enough to add a :
+	// 4) if the bottom of the stack was a ucerr.New(), just show the text
+	// 5) if the bottom of the stack was a ucerr.Wrap(), just show the base error
+	if msg == "" {
+		return t
+	} else if t == "" {
+		return msg
+	}
+
+	// 6) if the bottom of the stack was ucerr.Errorf(), show the original annotation + base error
+	return fmt.Sprintf("%s: %s", t, msg)
+}
+
+// Error implements error
+func (e ucError) Error() string {
+	var u string
+	if e.underlying != nil {
+		u = fmt.Sprintf("%s\n", e.underlying.Error())
+	}
+	return fmt.Sprintf("%s%s (File %s:%d, in %s)", u, e.text, e.filename, e.line, e.function)
+}
+
+// Unwrap implements errors.Unwrap for errors.Is
+func (e *ucError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.underlying // ok if this returns nil
+}
+
+// New creates a new ucerr
+func New(text string) error {
+	return new(text, nil, 1)
+}
+
+// Errorf is our local version of fmt.Errorf including callsite info
+func Errorf(temp string, args ...interface{}) error {
+	var wrapped error
+	// if using %w to wrap another error, use our wrapping mechanism
+	if strings.HasSuffix(temp, errorWrappingSuffix) {
+		temp = strings.TrimSuffix(temp, errorWrappingSuffix)
+		// use the safe cast in case this fails
+		var ok bool
+		wrapped, ok = args[len(args)-1].(error)
+		if !ok {
+			wrapped = New("seems as if ucerr.Errorf() was called with a non-error %w")
+		}
+		args = args[0 : len(args)-1]
+	}
+	return new(fmt.Sprintf(temp, args...), wrapped, 1)
+}
+
+// Wrap wraps an existing error with an additional level of the callstack
+func Wrap(err error) error {
+	if err == nil {
+		return nil
+	}
+	return new(wrappedText, err, 1)
+}
+
+// skips is the number of stack frames (besides new itself) to skip
+func new(text string, wraps error, skips int) error {
+	function, filename, line := whereAmI(skips + 1)
+	err := &ucError{
+		text:       text,
+		underlying: wraps,
+		function:   function,
+		filename:   filename,
+		line:       line,
+	}
+	return err
+}
+
+// s == stack frames to skip not including myself
+func whereAmI(s int) (string, string, int) {
+	pc, filename, line, ok := runtime.Caller(s + 1)
+	if !ok {
+		return "", "", 0
+	}
+	f := runtime.FuncForPC(pc)
+	return funcName(f.Name()), repoRelativePath(filename), line
+}

--- a/infra/ucerr/oautherror.go
+++ b/infra/ucerr/oautherror.go
@@ -1,0 +1,117 @@
+package ucerr
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// OAuthError implements error but can be marshalled to JSON
+// to make an OAuth/OIDC-compliant error.
+// TODO: Should this be a private type like `ucError`?
+type OAuthError struct {
+	ErrorType  string `json:"error"`
+	ErrorDesc  string `json:"error_description,omitempty"`
+	Code       int    `json:"-"`
+	underlying error
+}
+
+// Error implements interface `error` for type `OAuthError`
+func (o OAuthError) Error() string {
+	return fmt.Sprintf("%s: %s [http status: %d]", o.ErrorType, o.ErrorDesc, o.Code)
+}
+
+// Unwrap implements errors.Unwrap for errors.Is & errors.As
+func (o OAuthError) Unwrap() error {
+	return o.underlying // ok if this returns nil
+}
+
+// newWrappedOAuthError returns a new OAuthError wrapping a given error.
+func newWrappedOAuthError(err error, errorType string, code int) error {
+	return new(wrappedText, OAuthError{
+		ErrorType:  errorType,
+		ErrorDesc:  err.Error(),
+		Code:       code,
+		underlying: err,
+	}, 2)
+}
+
+// For future reference, here's the mapping of other OAuth errors to HTTP codes
+// that will likely become relevant to us:
+// invalid_scope - http.StatusBadRequest
+// invalid_client - http.StatusBadRequest or http.StatusUnauthorized (depending)
+// insufficient_scope - http.StatusForbidden
+// unauthorized_client - http.StatusForbidden
+// It's probably worth double checking the spec, Auth0 compatibility, etc. when the time comes.
+
+// ErrIncorrectUsernamePassword indicates a bad username or password.
+var ErrIncorrectUsernamePassword = OAuthError{
+	ErrorType: "invalid_grant",
+	ErrorDesc: "incorrect username or password",
+	Code:      http.StatusBadRequest,
+}
+
+// ErrInvalidAuthorizationCode indicates a bad authorization code.
+var ErrInvalidAuthorizationCode = OAuthError{
+	ErrorType: "invalid_grant",
+	ErrorDesc: "invalid code",
+	Code:      http.StatusBadRequest,
+}
+
+// ErrInvalidClientSecret indicates a bad client_secret.
+var ErrInvalidClientSecret = OAuthError{
+	ErrorType: "invalid_grant",
+	ErrorDesc: "invalid client secret",
+	Code:      http.StatusBadRequest,
+}
+
+// ErrInvalidAuthHeader indicates a bad HTTP Authorization header in an auth'd request.
+var ErrInvalidAuthHeader = OAuthError{
+	ErrorType: "invalid_token",
+	ErrorDesc: "invalid 'Authorization' header",
+	Code:      http.StatusUnauthorized,
+}
+
+// ErrInvalidCodeVerifier indicates a bad code_verifier argument in a Authorization Code w/PKCE login.
+var ErrInvalidCodeVerifier = OAuthError{
+	ErrorType: "invalid_grant",
+	ErrorDesc: "invalid code verifier",
+	Code:      http.StatusBadRequest,
+}
+
+// NewServerError returns a new internal server error.
+func NewServerError(err error) error {
+	return newWrappedOAuthError(err, "server_error", http.StatusInternalServerError)
+}
+
+// NewRequestError returns a new bad request error.
+func NewRequestError(err error) error {
+	return newWrappedOAuthError(err, "invalid_request", http.StatusBadRequest)
+}
+
+// NewUnsupportedGrantError returns a new error signifying an unsupported OAuth `grant_type`.
+func NewUnsupportedGrantError(grant string) error {
+	return new(wrappedText, OAuthError{
+		ErrorType: "unsupported_grant_type",
+		ErrorDesc: fmt.Sprintf("unsupported `grant_type` specified: %s", grant),
+		Code:      http.StatusBadRequest,
+	}, 1)
+}
+
+// NewUnsupportedResponseError returns a new error signifying an unsupported OAuth `response_type`.
+func NewUnsupportedResponseError(responseType string) error {
+	return new(wrappedText, OAuthError{
+		ErrorType: "unsupported_response_type",
+		ErrorDesc: fmt.Sprintf("unsupported `response_type` specified: %s", responseType),
+		Code:      http.StatusBadRequest,
+	}, 1)
+}
+
+// NewInvalidTokenError returns an error signifying a bad token of some kind.
+func NewInvalidTokenError(err error) error {
+	return newWrappedOAuthError(err, "invalid_token", http.StatusUnauthorized)
+}
+
+// NewInvalidClientError returns an error signifying a bad client ID.
+func NewInvalidClientError(err error) error {
+	return newWrappedOAuthError(err, "invalid_client", http.StatusBadRequest)
+}

--- a/infra/ucjwt/token.go
+++ b/infra/ucjwt/token.go
@@ -1,0 +1,92 @@
+package ucjwt
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/golang-jwt/jwt"
+
+	"userclouds.com/infra/oidc"
+	"userclouds.com/infra/ucerr"
+)
+
+const defaultTokenExpiry int64 = 86400
+
+// CreateToken creates a new JWT
+func CreateToken(ctx context.Context, privateKey *rsa.PrivateKey, keyID string, tokenID uuid.UUID, claims oidc.TokenClaims, jwtIssuerURL string) (string, error) {
+	// Augment claims with special fields.
+	claims.IssuedAt = time.Now().Unix()
+	claims.ExpiresAt = claims.IssuedAt + defaultTokenExpiry
+	claims.Issuer = jwtIssuerURL
+
+	// Put unique token ID in claims so we can track tokens back to any context around their issuance.
+	// As a side effect, we also get unique tokens which is currently required since we want to be able to look
+	// up each token issuance uniquely by the token.
+	claims.ID = tokenID.String()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = keyID
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", ucerr.Wrap(err)
+	}
+	return signedToken, nil
+}
+
+// ParseClaimsUnverified extracts the claims from a token without validating
+// its signature or anything else.
+func ParseClaimsUnverified(jwt string) (*oidc.TokenClaims, error) {
+	parts := strings.Split(jwt, ".")
+	if len(parts) < 2 {
+		return nil, ucerr.Errorf("malformed jwt, expected 3 parts got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, ucerr.Errorf("malformed jwt payload: %v", err)
+	}
+	var token oidc.TokenClaims
+	if err := json.Unmarshal(payload, &token); err != nil {
+		return nil, ucerr.Errorf("failed to unmarshal token/claims: %v", err)
+	}
+
+	return &token, nil
+}
+
+// IsExpired returns `true, nil` if the supplied JWT has valid claims and is expired,
+// `false, nil` if it has valid claims and is unexpired, and `true, err` if the claims
+// aren't parseable.
+// NOTE: It does NOT validate the token's signature!
+func IsExpired(jwt string) (bool, error) {
+	claims, err := ParseClaimsUnverified(jwt)
+	if err != nil {
+		return true, ucerr.Wrap(err)
+	}
+	if time.Unix(claims.ExpiresAt, 0).After(time.Now().UTC()) {
+		return false, nil
+	}
+	return true, nil
+}
+
+// ExtractBearerToken extracts a bearer token from an HTTP request or returns an error
+// if none is found or if it's malformed.
+// NOTE: this doesn't enforce that it's a JWT, much less a valid one.
+func ExtractBearerToken(h *http.Header) (string, error) {
+	bearerToken := h.Get("Authorization")
+	if bearerToken == "" {
+		return "", ucerr.New("authorization header required")
+	}
+
+	const bearerPrefix = "Bearer "
+	if !strings.HasPrefix(bearerToken, bearerPrefix) {
+		return "", ucerr.New("authorization header requires bearer token")
+	}
+
+	bearerToken = strings.TrimPrefix(bearerToken, bearerPrefix)
+	return bearerToken, nil
+}

--- a/samples/basic/.env.example
+++ b/samples/basic/.env.example
@@ -1,0 +1,5 @@
+# Fill in the values below and copy to `.env` in the same directory
+
+TENANT_URL=https://<yourtenant>.tenant.userclouds.com
+CLIENT_ID=your_client_ID_here
+CLIENT_SECRET=your_client_secret_here

--- a/samples/basic/authzhelper.go
+++ b/samples/basic/authzhelper.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/gofrs/uuid"
+	"userclouds.com/authz"
+	"userclouds.com/idp"
+	"userclouds.com/infra/jsonclient"
+	"userclouds.com/infra/ucerr"
+)
+
+// NB: most of the methods in this file should end up in the public SDK in some form, as they're generally useful
+// for idempotent creation of objects, types, etc.
+
+// isBenign returns true if there is no error or if the error is safely ignorable (e.g. resource already created)
+// during initial setup & provisioning.
+func isBenign(err error) bool {
+	if err == nil {
+		return true
+	}
+	var clientErr jsonclient.Error
+	if errors.As(err, &clientErr) {
+		// Resource already exists
+		if clientErr.StatusCode == http.StatusConflict {
+			return true
+		}
+	}
+	return false
+}
+
+func provisionObjectType(ctx context.Context, authZClient *authz.Client, typeName string) (uuid.UUID, error) {
+	if _, err := authZClient.CreateObjectType(ctx, uuid.Must(uuid.NewV4()), typeName); !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	id, err := authZClient.FindObjectTypeID(ctx, typeName)
+	if err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	return id, err
+}
+
+func provisionEdgeType(ctx context.Context, authZClient *authz.Client, sourceObjectID, targetObjectID uuid.UUID, typeName string) (uuid.UUID, error) {
+	if _, err := authZClient.CreateEdgeType(ctx, uuid.Must(uuid.NewV4()), sourceObjectID, targetObjectID, typeName); !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	id, err := authZClient.FindEdgeTypeID(ctx, typeName)
+	if err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	return id, err
+}
+
+func provisionObject(ctx context.Context, authZClient *authz.Client, typeID uuid.UUID, alias string) (uuid.UUID, error) {
+	obj, err := authZClient.CreateObject(ctx, uuid.Must(uuid.NewV4()), typeID, alias)
+	if !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	return obj.ID, nil
+}
+
+func provisionUser(ctx context.Context, idpClient *idp.Client, username, password string, profile idp.UserProfile) (uuid.UUID, error) {
+	var err error
+	if _, err = idpClient.CreateUserWithPassword(ctx, username, password, profile); !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	users, err := idpClient.ListUsersForEmail(ctx, profile.Email, idp.AuthnTypePassword)
+	if err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	if len(users) != 1 {
+		return uuid.Nil, ucerr.Errorf("expected 1 user with email '%s', got %d", profile.Email, len(users))
+	}
+	return users[0].ID, nil
+}
+
+func enumerateTeams(ctx context.Context, authZClient *authz.Client, userID uuid.UUID) ([]uuid.UUID, error) {
+	edges, err := authZClient.ListEdges(ctx, userID)
+	if err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	teams := []uuid.UUID{}
+	for _, v := range edges {
+		if v.EdgeTypeID == TeamMemberID {
+			teams = append(teams, v.SourceObjectID)
+		}
+	}
+	return teams, nil
+}
+
+// mustID panics if a UUID-producing operation returns an error, otherwise it returns the UUID
+func mustID(id uuid.UUID, err error) uuid.UUID {
+	if err != nil {
+		log.Fatalf("mustID error: %v", err)
+	}
+	if id == uuid.Nil {
+		log.Fatal("mustID error: unexpected nil uuid")
+	}
+	return id
+}

--- a/samples/basic/filemanager.go
+++ b/samples/basic/filemanager.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/gofrs/uuid"
+	"userclouds.com/authz"
+	"userclouds.com/idp"
+	"userclouds.com/infra/ucerr"
+)
+
+// FileManager is a simple class that can create file systems with permissions.
+type FileManager struct {
+	authZClient *authz.Client
+}
+
+func NewFileManager(authZClient *authz.Client) *FileManager {
+	return &FileManager{
+		authZClient: authZClient,
+	}
+}
+
+// File represents a file/directory that is part of a tree. Only directories can have child files.
+// The ID of the file is used as a key in the permission system to manage ACLs.
+type File struct {
+	id   uuid.UUID
+	name string
+
+	isDir bool
+
+	parent   *File
+	children []*File
+}
+
+func (f File) FullPath() string {
+	if f.parent == nil {
+		return fmt.Sprintf("file://%s", f.id.String())
+	} else {
+		return fmt.Sprintf("%s/%s", f.parent.FullPath(), f.name)
+	}
+}
+
+func (f File) FindFile(name string) *File {
+	if !f.isDir {
+		return nil
+	}
+
+	for _, v := range f.children {
+		if v.name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+func (fm *FileManager) HasWriteAccess(ctx context.Context, f *File, userID uuid.UUID) error {
+	cur := f
+	// NB: with inheritance support, the team enumeration would be implicitly handled by the propagation rules
+	teams, err := enumerateTeams(ctx, fm.authZClient, userID)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	for cur != nil {
+		// NB: currently we only support RBAC without Attributes; instead of `FindEdge`, we should use `CheckAttribute` which enumerates all edges
+		// between two objects to see if any edge has the desired attribute. This allows for multiple roles to have overlapping attributes, and for
+		// the creation of new roles with new combinations of attributes without touching all permission checking vode.
+		// NB: with permission inheritance, there would be additional edges between parent<>children files, and the AuthZ API will run the graph
+		// BFS on the backend and propagate permissions/attributes based on the edge definitions. Furthermore, team membership would also inherit permissions.
+		// For now, the inheritance is handled client-side.
+		if _, err := fm.authZClient.FindEdge(ctx, cur.id, userID, FileEditorTypeID); err == nil {
+			return nil
+		}
+		// NB: with inheritance support, these extra calls won't be needed
+		for _, teamID := range teams {
+			if _, err := fm.authZClient.FindEdge(ctx, cur.id, teamID, FileTeamEditorTypeID); err == nil {
+				return nil
+			}
+		}
+		cur = cur.parent
+	}
+	return ucerr.Errorf("user %v does not have write permissions on file %+v", userID, f)
+}
+
+func (fm *FileManager) HasReadAccess(ctx context.Context, f *File, userID uuid.UUID) error {
+	cur := f
+	// NB: with inheritance support, the team enumeration would be implicitly handled by the propagation rules
+	teams, err := enumerateTeams(ctx, fm.authZClient, userID)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+	for cur != nil {
+		// NB: with Attribute support this will be simpler; we can just call CheckAttribute instead of testing multiple edge types
+		if _, err := fm.authZClient.FindEdge(ctx, cur.id, userID, FileEditorTypeID); err == nil {
+			return nil
+		}
+		if _, err := fm.authZClient.FindEdge(ctx, cur.id, userID, FileViewerTypeID); err == nil {
+			return nil
+		}
+
+		// NB: with inheritance support, these extra calls won't be needed
+		for _, teamID := range teams {
+			if _, err := fm.authZClient.FindEdge(ctx, cur.id, teamID, FileTeamEditorTypeID); err == nil {
+				return nil
+			}
+			if _, err := fm.authZClient.FindEdge(ctx, cur.id, teamID, FileTeamViewerTypeID); err == nil {
+				return nil
+			}
+		}
+
+		cur = cur.parent
+	}
+	return ucerr.Errorf("user %v does not have read permissions on file %+v", userID, f)
+}
+
+func (fm *FileManager) NewRoot(ctx context.Context, creatorUserID uuid.UUID) (*File, error) {
+	f := &File{
+		id:       uuid.Must(uuid.NewV4()),
+		name:     "",
+		isDir:    true,
+		parent:   nil,
+		children: []*File{},
+	}
+
+	// If the first operation fails, nothing is created and the operation fails.
+	// If the first succeeds but the second fails, we'll have an orphan authz object to clean-up that is harmless and could be reaped later.
+	// NB: We will eventually support Transactions for this, which avoids orphans.
+	if _, err := fm.authZClient.CreateObject(ctx, f.id, FileTypeID, f.FullPath()); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	// Give the creator of the file Editor permission by default (you could get fancy and have "owner"/"creator"/"admin" access on top too)
+	if _, err := fm.authZClient.CreateEdge(ctx, uuid.Must(uuid.NewV4()), f.id, creatorUserID, FileEditorTypeID); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return f, nil
+}
+
+func (fm *FileManager) newFileHelper(ctx context.Context, name string, isDir bool, parent *File, creatorUserID uuid.UUID) (*File, error) {
+	if !parent.isDir {
+		return nil, ucerr.Errorf("cannot create files or directories under a file: %+v", parent)
+	}
+
+	if parent.FindFile(name) != nil {
+		return nil, ucerr.Errorf("file with name '%s' already exists in %+v", name, parent)
+	}
+
+	if err := fm.HasWriteAccess(ctx, parent, creatorUserID); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	f := &File{
+		id:       uuid.Must(uuid.NewV4()),
+		name:     name,
+		isDir:    isDir,
+		parent:   parent,
+		children: []*File{},
+	}
+
+	if _, err := fm.authZClient.CreateObject(ctx, f.id, FileTypeID, f.FullPath()); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	parent.children = append(parent.children, f)
+
+	// NB: since the creator has write access to the parent, we don't need to explicitly grant it on the child
+
+	return f, nil
+}
+
+func (fm *FileManager) NewFile(ctx context.Context, name string, parent *File, creatorUserID uuid.UUID) (*File, error) {
+	f, err := fm.newFileHelper(ctx, name, false, parent, creatorUserID)
+	return f, ucerr.Wrap(err)
+}
+
+func (fm *FileManager) NewDir(ctx context.Context, name string, parent *File, creatorUserID uuid.UUID) (*File, error) {
+	f, err := fm.newFileHelper(ctx, name, true, parent, creatorUserID)
+	return f, ucerr.Wrap(err)
+}
+
+func (fm *FileManager) ReadFile(ctx context.Context, f *File, readerUserID uuid.UUID) (string, error) {
+	if err := fm.HasReadAccess(ctx, f, readerUserID); err != nil {
+		return "", ucerr.Wrap(err)
+	}
+
+	return fmt.Sprintf("contents of file %s", f.FullPath()), nil
+}
+
+// mustFile panics if a file-producing operation returns an error, otherwise it returns the file
+func mustFile(f *File, err error) *File {
+	if err != nil {
+		log.Fatalf("mustFile error: %v", err)
+	}
+	if f == nil {
+		log.Fatal("mustFile error: unexpected nil file")
+	}
+	return f
+}
+
+const leftColWidth = 50
+
+func summarizePermissions(ctx context.Context, idpClient *idp.Client, authZClient *authz.Client, f *File) string {
+	edges, err := authZClient.ListEdges(ctx, f.id)
+	if err != nil {
+		return "<error fetching edges>"
+	}
+	permsList := ""
+	for _, e := range edges {
+		et, err := authZClient.GetEdgeType(ctx, e.EdgeTypeID)
+		if err != nil {
+			return "<error fetching edge type>"
+		}
+		var otherID uuid.UUID
+		if e.SourceObjectID == f.id {
+			otherID = e.TargetObjectID
+		} else {
+			otherID = e.SourceObjectID
+		}
+		obj, err := authZClient.GetObject(ctx, otherID)
+		if err != nil {
+			return "<error fetching object>"
+		}
+		displayName := obj.Alias
+		if obj.TypeID == authz.UserObjectTypeID {
+			user, err := idpClient.GetUser(ctx, obj.ID)
+			if err != nil {
+				return "<error fetching user>"
+			}
+			displayName = user.Name
+		}
+		perm := fmt.Sprintf("%s (%s)", displayName, et.TypeName)
+		if len(permsList) == 0 {
+			permsList = perm
+		} else {
+			permsList = fmt.Sprintf("%s, %s", permsList, perm)
+		}
+	}
+	return permsList
+}
+
+func renderFileTree(ctx context.Context, idpClient *idp.Client, authZClient *authz.Client, f *File, indentLevel int) {
+	outStr := ""
+	if f.parent == nil {
+		outStr += "/"
+	} else {
+		for i := 0; i < indentLevel-1; i++ {
+			outStr += "      "
+		}
+		outStr += "^---> "
+		outStr += f.name
+	}
+
+	for i := len(outStr); i < leftColWidth; i++ {
+		outStr += " "
+	}
+	outStr += fmt.Sprintf("| %s", summarizePermissions(ctx, idpClient, authZClient, f))
+	fmt.Println(outStr)
+
+	for _, v := range f.children {
+		renderFileTree(ctx, idpClient, authZClient, v, indentLevel+1)
+	}
+}

--- a/samples/basic/main.go
+++ b/samples/basic/main.go
@@ -411,7 +411,7 @@ func main() {
 
 	err := godotenv.Load()
 	if err != nil {
-		log.Fatalf("error loading .env file: %v", err)
+		log.Fatalf("error loading .env file: %v\n(did you forget to copy `.env.example` to `.env` and substitute values?)", err)
 	}
 
 	tenantURL := os.Getenv("TENANT_URL")

--- a/samples/basic/main.go
+++ b/samples/basic/main.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gofrs/uuid"
+	"github.com/joho/godotenv"
+
+	"userclouds.com/authz"
+	"userclouds.com/idp"
+	"userclouds.com/infra/jsonclient"
+	"userclouds.com/infra/ucerr"
+)
+
+func isBenign(err error) bool {
+	if err == nil {
+		return true
+	}
+	var clientErr jsonclient.Error
+	if errors.As(err, &clientErr) {
+		// Resource already exists
+		if clientErr.StatusCode == http.StatusConflict {
+			return true
+		}
+	}
+	return false
+}
+
+// Object type IDs
+var FileTypeID, TeamTypeID uuid.UUID
+
+// Edge type IDs (i.e. roles)
+var TeamMemberID uuid.UUID
+var FileEditorTypeID, FileViewerTypeID uuid.UUID
+var FileTeamEditorTypeID, FileTeamViewerTypeID uuid.UUID
+
+var AliceUserID, BobUserID uuid.UUID
+
+func provisionObjectType(ctx context.Context, authZClient *authz.Client, typeName string) (uuid.UUID, error) {
+	if _, err := authZClient.CreateObjectType(ctx, uuid.Must(uuid.NewV4()), typeName); !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	id, err := authZClient.FindObjectTypeID(ctx, typeName)
+	if err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	return id, err
+}
+
+func provisionEdgeType(ctx context.Context, authZClient *authz.Client, sourceObjectID, targetObjectID uuid.UUID, typeName string) (uuid.UUID, error) {
+	if _, err := authZClient.CreateEdgeType(ctx, uuid.Must(uuid.NewV4()), sourceObjectID, targetObjectID, typeName); !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	id, err := authZClient.FindEdgeTypeID(ctx, typeName)
+	if err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	return id, err
+}
+
+func provisionObject(ctx context.Context, authZClient *authz.Client, typeID uuid.UUID, alias string) (uuid.UUID, error) {
+	obj, err := authZClient.CreateObject(ctx, uuid.Must(uuid.NewV4()), typeID, alias)
+	if !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	return obj.ID, nil
+}
+
+func provisionUser(ctx context.Context, idpClient *idp.Client, username, password string, profile idp.UserProfile) (uuid.UUID, error) {
+	var err error
+	if _, err = idpClient.CreateUserWithPassword(ctx, username, password, profile); !isBenign(err) {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	users, err := idpClient.ListUsersForEmail(ctx, profile.Email, idp.AuthnTypePassword)
+	if err != nil {
+		return uuid.Nil, ucerr.Wrap(err)
+	}
+	if len(users) != 1 {
+		return uuid.Nil, ucerr.Errorf("expected 1 user with email '%s', got %d", profile.Email, len(users))
+	}
+	return users[0].ID, nil
+}
+
+func enumerateTeams(ctx context.Context, authZClient *authz.Client, userID uuid.UUID) ([]uuid.UUID, error) {
+	edges, err := authZClient.ListEdges(ctx, userID)
+	if err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	teams := []uuid.UUID{}
+	for _, v := range edges {
+		if v.EdgeTypeID == TeamMemberID {
+			teams = append(teams, v.SourceObjectID)
+		}
+	}
+	return teams, nil
+}
+
+func ensureID(id uuid.UUID, err error) uuid.UUID {
+	if err != nil {
+		log.Fatalf("ensureID error: %v", err)
+	}
+	if id == uuid.Nil {
+		log.Fatal("ensureID error: unexpected nil uuid")
+	}
+	return id
+}
+
+func oneTimeProvision(ctx context.Context, idpClient *idp.Client, authZClient *authz.Client) error {
+	// NB: these Create commands are only here because this is a self-contained sample app; normally
+	// you would do one-time provisioning via the Console or via API ahead of time, not in every single app instance!
+	//
+	// You can either generate some UUIDs ahead of time and compile them in as constants for each tenant, or query them at runtime.
+	FileTypeID = ensureID(provisionObjectType(ctx, authZClient, "file"))
+	TeamTypeID = ensureID(provisionObjectType(ctx, authZClient, "team"))
+
+	TeamMemberID = ensureID(provisionEdgeType(ctx, authZClient, TeamTypeID, authz.UserObjectTypeID, "team_member"))
+	FileEditorTypeID = ensureID(provisionEdgeType(ctx, authZClient, FileTypeID, authz.UserObjectTypeID, "file_editor"))
+	FileViewerTypeID = ensureID(provisionEdgeType(ctx, authZClient, FileTypeID, authz.UserObjectTypeID, "file_viewer"))
+	FileTeamEditorTypeID = ensureID(provisionEdgeType(ctx, authZClient, FileTypeID, TeamTypeID, "file_team_editor"))
+	FileTeamViewerTypeID = ensureID(provisionEdgeType(ctx, authZClient, FileTypeID, TeamTypeID, "file_team_viewer"))
+
+	// Create a few test users (normally users would sign up via the UI, so this is contrived too)
+	AliceUserID = ensureID(provisionUser(ctx, idpClient, "alice", "password_alice_123!", idp.UserProfile{
+		Email:    "alice@example.com",
+		Name:     "Alice Aardvark",
+		Nickname: "Allie",
+	}))
+
+	BobUserID = ensureID(provisionUser(ctx, idpClient, "bob", "password_bob_123!", idp.UserProfile{
+		Email:    "bob@example.com",
+		Name:     "Bob Birdie",
+		Nickname: "Bobby",
+	}))
+
+	// Clean up all files, folders, etc
+	return nil
+}
+
+func tryCleanPreviousRuns(ctx context.Context, authZClient *authz.Client) error {
+	objs, err := authZClient.ListObjects(ctx)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+	for _, v := range objs {
+		if v.TypeID == FileTypeID || v.TypeID == TeamTypeID {
+			if err := authZClient.DeleteObject(ctx, v.ID); err != nil {
+				log.Printf("warning, failed to delete %+v", v)
+			}
+		}
+	}
+	return nil
+}
+
+type FileManager struct {
+	authZClient *authz.Client
+}
+
+func NewFileManager(authZClient *authz.Client) *FileManager {
+	return &FileManager{
+		authZClient: authZClient,
+	}
+}
+
+type File struct {
+	id   uuid.UUID
+	name string
+
+	isDir bool
+
+	parent   *File
+	children []*File
+}
+
+func (f File) FullPath() string {
+	if f.parent == nil {
+		return fmt.Sprintf("%s://", f.id.String())
+	} else {
+		return fmt.Sprintf("%s/%s", f.parent.FullPath(), f.name)
+	}
+}
+
+func (f File) FindFile(name string) *File {
+	if !f.isDir {
+		return nil
+	}
+
+	for _, v := range f.children {
+		if v.name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+func (fm *FileManager) HasWriteAccess(ctx context.Context, f *File, userID uuid.UUID) error {
+	cur := f
+	// NB: with inheritance support, the team enumeration would be implicitly handled by the propagation rules
+	teams, err := enumerateTeams(ctx, fm.authZClient, userID)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+
+	for cur != nil {
+		// NB: currently we only support RBAC without Attributes; instead of `FindEdge`, we should use `CheckAttribute` which enumerates all edges
+		// between two objects to see if any edge has the desired attribute. This allows for multiple roles to have overlapping attributes, and for
+		// the creation of new roles with new combinations of attributes without touching all permission checking vode.
+		// NB: with permission inheritance, there would be additional edges between parent<>children files, and the AuthZ API will run the graph
+		// BFS on the backend and propagate permissions/attributes based on the edge definitions. Furthermore, team membership would also inherit permissions.
+		// For now, the inheritance is handled client-side.
+		if _, err := fm.authZClient.FindEdge(ctx, cur.id, userID, FileEditorTypeID); err == nil {
+			return nil
+		}
+		// NB: with inheritance support, these extra calls won't be needed
+		for _, teamID := range teams {
+			if _, err := fm.authZClient.FindEdge(ctx, cur.id, teamID, FileTeamEditorTypeID); err == nil {
+				return nil
+			}
+		}
+		cur = cur.parent
+	}
+	return ucerr.Errorf("user %v does not have write permissions on file %+v", userID, f)
+}
+
+func (fm *FileManager) HasReadAccess(ctx context.Context, f *File, userID uuid.UUID) error {
+	cur := f
+	// NB: with inheritance support, the team enumeration would be implicitly handled by the propagation rules
+	teams, err := enumerateTeams(ctx, fm.authZClient, userID)
+	if err != nil {
+		return ucerr.Wrap(err)
+	}
+	for cur != nil {
+		// NB: with Attribute support this will be simpler; we can just call CheckAttribute instead of testing multiple edge types
+		if _, err := fm.authZClient.FindEdge(ctx, cur.id, userID, FileEditorTypeID); err == nil {
+			return nil
+		}
+		if _, err := fm.authZClient.FindEdge(ctx, cur.id, userID, FileViewerTypeID); err == nil {
+			return nil
+		}
+
+		// NB: with inheritance support, these extra calls won't be needed
+		for _, teamID := range teams {
+			if _, err := fm.authZClient.FindEdge(ctx, cur.id, teamID, FileTeamEditorTypeID); err == nil {
+				return nil
+			}
+			if _, err := fm.authZClient.FindEdge(ctx, cur.id, teamID, FileTeamViewerTypeID); err == nil {
+				return nil
+			}
+		}
+
+		cur = cur.parent
+	}
+	return ucerr.Errorf("user %v does not have read permissions on file %+v", userID, f)
+}
+
+func (fm *FileManager) NewRoot(ctx context.Context, creatorUserID uuid.UUID) (*File, error) {
+	f := &File{
+		id:       uuid.Must(uuid.NewV4()),
+		name:     "",
+		isDir:    true,
+		parent:   nil,
+		children: []*File{},
+	}
+
+	// If the first operation fails, nothing is created and the operation fails.
+	// If the first succeeds but the second fails, we'll have an orphan authz object to clean-up that is harmless and could be reaped later.
+	// NB: We will eventually support Transactions for this, which avoids orphans.
+	if _, err := fm.authZClient.CreateObject(ctx, f.id, FileTypeID, f.FullPath()); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	// Give the creator of the file Editor permission by default (you could get fancy and have "owner"/"creator"/"admin" access on top too)
+	if _, err := fm.authZClient.CreateEdge(ctx, uuid.Must(uuid.NewV4()), f.id, creatorUserID, FileEditorTypeID); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	return f, nil
+}
+
+func (fm *FileManager) newFileHelper(ctx context.Context, name string, isDir bool, parent *File, creatorUserID uuid.UUID) (*File, error) {
+	if !parent.isDir {
+		return nil, ucerr.Errorf("cannot create files or directories under a file: %+v", parent)
+	}
+
+	if parent.FindFile(name) != nil {
+		return nil, ucerr.Errorf("file with name '%s' already exists in %+v", name, parent)
+	}
+
+	if err := fm.HasWriteAccess(ctx, parent, creatorUserID); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	f := &File{
+		id:       uuid.Must(uuid.NewV4()),
+		name:     name,
+		isDir:    isDir,
+		parent:   parent,
+		children: []*File{},
+	}
+
+	if _, err := fm.authZClient.CreateObject(ctx, f.id, FileTypeID, f.FullPath()); err != nil {
+		return nil, ucerr.Wrap(err)
+	}
+
+	// NB: since the creator has write access to the parent, we don't need to explicitly grant it on the child
+
+	return f, nil
+}
+
+func (fm *FileManager) NewFile(ctx context.Context, name string, parent *File, creatorUserID uuid.UUID) (*File, error) {
+	f, err := fm.newFileHelper(ctx, name, false, parent, creatorUserID)
+	return f, ucerr.Wrap(err)
+}
+
+func (fm *FileManager) NewDir(ctx context.Context, name string, parent *File, creatorUserID uuid.UUID) (*File, error) {
+	f, err := fm.newFileHelper(ctx, name, true, parent, creatorUserID)
+	return f, ucerr.Wrap(err)
+}
+
+func (fm *FileManager) ReadFile(ctx context.Context, f *File, readerUserID uuid.UUID) (string, error) {
+	if err := fm.HasReadAccess(ctx, f, readerUserID); err != nil {
+		return "", ucerr.Wrap(err)
+	}
+
+	return fmt.Sprintf("contents of file %s", f.FullPath()), nil
+}
+
+func ensureFile(f *File, err error) *File {
+	if err != nil {
+		log.Fatalf("ensureFile error: %v", err)
+	}
+	if f == nil {
+		log.Fatal("ensureFile error: unexpected nil file")
+	}
+	return f
+}
+
+func main() {
+	ctx := context.Background()
+
+	err := godotenv.Load()
+	if err != nil {
+		log.Fatalf("error loading .env file: %v", err)
+	}
+
+	tenantURL := os.Getenv("TENANT_URL")
+	clientID := os.Getenv("CLIENT_ID")
+	clientSecret := os.Getenv("CLIENT_SECRET")
+
+	tokenSource := jsonclient.ClientCredentialsTokenSource(tenantURL+"/oidc/token", clientID, clientSecret, nil)
+
+	idpClient, err := idp.NewClient(tenantURL, tokenSource)
+	if err != nil {
+		log.Fatalf("error initializing idp client: %v", err)
+	}
+
+	authZClient, err := authz.NewClient(tenantURL, tokenSource)
+	if err != nil {
+		log.Fatalf("error initializing authz client: %v", err)
+	}
+
+	if err := oneTimeProvision(ctx, idpClient, authZClient); err != nil {
+		log.Fatalf("error provisioning basic authz types: %v", err)
+	}
+
+	if err := tryCleanPreviousRuns(ctx, authZClient); err != nil {
+		log.Printf("failed to clean previous run data, ignoring and moving on")
+	}
+
+	fm := NewFileManager(authZClient)
+
+	// Alice creates the root directory and has full permissions
+	rootDir := ensureFile(fm.NewRoot(ctx, AliceUserID))
+	// Alice can create '/dir1' and '/dir2'
+	dir1 := ensureFile(fm.NewDir(ctx, "dir1", rootDir, AliceUserID))
+	dir2 := ensureFile(fm.NewDir(ctx, "dir2", rootDir, AliceUserID))
+
+	// Bob cannot create files in '/dir1'
+	_, err = fm.NewFile(ctx, "file1", dir1, BobUserID)
+	if err == nil {
+		log.Fatalf("expected Bob to fail to create file under dir1")
+	}
+
+	// Alice can create files in '/dir1'
+	file1 := ensureFile(fm.NewFile(ctx, "file1", dir1, AliceUserID))
+
+	// Bob cannot read '/dir1/file1'
+	if _, err = fm.ReadFile(ctx, file1, BobUserID); err == nil {
+		log.Fatalf("expected Bob to fail to read file1")
+	}
+
+	// Grant Bob viewer permissions in 'dir1'
+	_ = ensureID(authZClient.CreateEdge(ctx, uuid.Must(uuid.NewV4()), dir1.id, BobUserID, FileViewerTypeID))
+
+	// Now Bob can read '/dir1/file1'
+	if _, err := fm.ReadFile(ctx, file1, BobUserID); err != nil {
+		log.Fatalf("expected Bob to succeed reading dir1/file1: %v", err)
+	}
+
+	// Bob cannot (yet) create subdirectories under '/dir2'
+	_, err = fm.NewDir(ctx, "dir3", dir2, BobUserID)
+	if err == nil {
+		log.Fatalf("expected Bob to fail to create dir3 under /dir2")
+	}
+
+	// Create a team, add Bob to it, give that team write permissions to '/dir2'
+	aliceReportsTeamID := ensureID(provisionObject(ctx, authZClient, TeamTypeID, "Alice's Direct Reports"))
+	_ = ensureID(authZClient.CreateEdge(ctx, uuid.Must(uuid.NewV4()), aliceReportsTeamID, BobUserID, TeamMemberID))
+	_ = ensureID(authZClient.CreateEdge(ctx, uuid.Must(uuid.NewV4()), dir2.id, aliceReportsTeamID, FileTeamEditorTypeID))
+
+	// Now Bob can create subdirectories under '/dir2'
+	if _, err := fm.NewDir(ctx, "dir3", dir2, BobUserID); err != nil {
+		log.Fatalf("expected Bob to succeed creating dir3 under /dir2: %v", err)
+	}
+
+	// But still not under '/dir1'
+	_, err = fm.NewDir(ctx, "dir3", dir1, BobUserID)
+	if err == nil {
+		log.Fatalf("expected Bob to fail to create dir3 under /dir1")
+	}
+
+	log.Printf("succssfully ran sample")
+}


### PR DESCRIPTION
In this PR, I started by copying the minimum set of files necessary to use the IDP & AuthZ clients in a sample app that can be distributed to customers.

This PR also includes a sample AuthZ app showing a non-trivial case of users + teams, and recursive/hierarchical folders & files. Several of the more complex permission checking APIs will be greatly simplified when we introduce Attributes and Hierarchy.

NOTE: this uses the version of the authz client + dependencies from https://github.com/userclouds/userclouds/pull/400, which was required in order to sever a few heavyweight dependencies such as `uclog`, `ucjwt`, etc

For testing, you can use a staging client ID & secret I created - just create a `.env` file in the sample directory (where `.env.example` is checked in) and use these values:
```
TENANT_URL=https://authzsamples.tenant.staging.userclouds.com
CLIENT_ID=0604723cc5eb03d854682dd6ce7bd6fc
CLIENT_SECRET=OOVDpgh7ur0RZ/SrVZxT/48JUhGsFOP/s6gnopwmax5XSmvfzus+hXMe/r7kQZLx
```

TODOs:
- [x] Add a flag or method to our JSON client in our private repo to capture error logging so we have it for internal server use cases but NOT public SDK use cases. The cheap/easy thing is to create a separate file in the same package with a private method like `logError()` which is different in the private vs public repo.
- [x] Add some logging methods to 'render' the file tree and permissions