### PR TITLE
Update sample app with inheritance/attribute support

### DIFF
--- a/authz/attribute_validate_generated.go
+++ b/authz/attribute_validate_generated.go
@@ -1,0 +1,19 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package authz
+
+import (
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate implements Validateable
+func (o *Attribute) Validate() error {
+	// .extraValidate() lets you do any validation you can't express in codegen tags yet
+	if err := o.extraValidate(); err != nil {
+		return ucerr.Wrap(err)
+	}
+	if o.Name == "" {
+		return ucerr.Errorf("Attribute.Name can't be empty")
+	}
+	return nil
+}

--- a/authz/edge_validate_generated.go
+++ b/authz/edge_validate_generated.go
@@ -1,0 +1,26 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package authz
+
+import (
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate implements Validateable
+func (o *Edge) Validate() error {
+	if err := o.BaseModel.Validate(); err != nil {
+		return ucerr.Wrap(err)
+	}
+	if o.EdgeTypeID == uuid.Nil {
+		return ucerr.Errorf("Edge.EdgeTypeID (%v) can't be nil", o.ID)
+	}
+	if o.SourceObjectID == uuid.Nil {
+		return ucerr.Errorf("Edge.SourceObjectID (%v) can't be nil", o.ID)
+	}
+	if o.TargetObjectID == uuid.Nil {
+		return ucerr.Errorf("Edge.TargetObjectID (%v) can't be nil", o.ID)
+	}
+	return nil
+}

--- a/authz/edgetype_validate_generated.go
+++ b/authz/edgetype_validate_generated.go
@@ -1,0 +1,31 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package authz
+
+import (
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate implements Validateable
+func (o *EdgeType) Validate() error {
+	if err := o.BaseModel.Validate(); err != nil {
+		return ucerr.Wrap(err)
+	}
+	if o.TypeName == "" {
+		return ucerr.Errorf("EdgeType.TypeName (%v) can't be empty", o.ID)
+	}
+	if o.SourceObjectTypeID == uuid.Nil {
+		return ucerr.Errorf("EdgeType.SourceObjectTypeID (%v) can't be nil", o.ID)
+	}
+	if o.TargetObjectTypeID == uuid.Nil {
+		return ucerr.Errorf("EdgeType.TargetObjectTypeID (%v) can't be nil", o.ID)
+	}
+	for i := range o.Attributes {
+		if err := o.Attributes[i].Validate(); err != nil {
+			return ucerr.Wrap(err)
+		}
+	}
+	return nil
+}

--- a/authz/models.go
+++ b/authz/models.go
@@ -11,59 +11,88 @@ import (
 type ObjectType struct {
 	ucdb.BaseModel
 
-	TypeName string `db:"type_name" json:"type_name"`
+	TypeName string `db:"type_name" json:"type_name" validate:"notempty"`
 }
 
-// Validate implements Validateable
-func (o ObjectType) Validate() error {
-	if o.TypeName == "" {
-		return ucerr.New("TypeName can't be empty")
-	}
-	return ucerr.Wrap(o.BaseModel.Validate())
+//go:generate genvalidate ObjectType
+
+// Attribute represents a named attribute on an Edge Type.
+type Attribute struct {
+	Name string `db:"name" json:"name" validate:"notempty"`
+
+	// Direct = true means that this attribute applies directly from the source to the target, or
+	// alternately stated that "the source object 'has' the attribute on the target".
+	// e.g. given an edge {Source: Alice, Target: Readme.txt, Type: Viewer} with attribute {Name:"read", Direct: true},
+	// then Alice directly 'has' the "read" attribute on Readme.txt
+	Direct bool `db:"direct" json:"direct"`
+
+	// Inherit = true means that, if the target object 'has' (or inherits) the attribute on some other object X,
+	// then the source object "inherits" that attribute on X as well. This applies transitively across
+	// multiple consecutive Inherit edges.
+	// e.g. given an edge {Source: Alice, Target: RootUsersGroup, Type: Member} with attribute {Name:"read", Inherit: true},
+	// and another edge {Source: RootUsersGroup, Target: Readme.txt, Type: Viewer} with attribute {Name:"read", Direct: true},
+	// then the Root Users group has direct read permissions on Readme.txt and Alice inherits the read permission
+	// on Readme.txt through its connection to the RootUsersGroup.
+	// This flag is typically used when some objects (e.g. users, files) should inherit attributes
+	// that a "grouping" object has on some final target object without requiring direct edges between
+	// every source and every target (e.g. between Alice and Readme.txt, in this example).
+	// The Inherit flag would be used on attributes that associate the source objects with the grouping object.
+	// This is like a "pull" model for permissions, while Propagate represents a "push" model.
+	Inherit bool `db:"inherit" json:"inherit"`
+
+	// Propagate = true means that some object X which has an attribute on the source object will also have the same
+	// attribute on the target object. This is effectively the inverse of Inherit, and "propagates" attributes forward.
+	// e.g. given an edge {Source: Alice, Target: HomeDirectory, Type: Viewer} with attribute {Name: "read", Direct: true},
+	// and another edge {Source: HomeDirectory, Target: Readme.txt, Type: Contains} with attribute {Name: "read", Propagate: true},
+	// then Alice's read permission on the HomeDirectory propagates to Readme.txt since that is (presumably) contained in the
+	// Home directory.
+	// This is like a "push" model for permissions, while Inherit represents a "pull" model.
+	// This is different from Direct = true because it doesn't make sense for the Home directory to have
+	// direct "read" attributes on files within it, but simply propagate the permissions down the tree.
+	// Permissions don't propagate through Direct links; if Alice has a 'direct' "friend" relationship to Bob,
+	// and Bob has a 'direct' "friend" relationship to Charlie,
+	// that wouldn't imply Alice has a 'direct' "friend" relationship to Charlie (direct != propagate).
+	Propagate bool `db:"propagate" json:"propagate"`
 }
+
+func (a *Attribute) extraValidate() error {
+	if (a.Direct && !a.Inherit && !a.Propagate) ||
+		(!a.Direct && a.Inherit && !a.Propagate) ||
+		(!a.Direct && !a.Inherit && a.Propagate) {
+		return nil
+	}
+	return ucerr.Errorf("exactly 1 of Attribute.{Direct, Inherit, Propagate} must be true; got {%t, %t, %t} instead", a.Direct, a.Inherit, a.Propagate)
+}
+
+//go:generate genvalidate Attribute
+
+// Attributes is a collection of Attribute, used as a column/field in EdgeType
+type Attributes []Attribute
+
+//go:generate gendbjson Attributes
 
 // EdgeType defines a single, strongly-typed relationship
 // that a "source" object type can have to a "target" object type.
 type EdgeType struct {
 	ucdb.BaseModel
 
-	TypeName           string    `db:"type_name" json:"type_name"`
-	SourceObjectTypeID uuid.UUID `db:"source_object_type_id,immutable" json:"source_object_type_id"`
-	TargetObjectTypeID uuid.UUID `db:"target_object_type_id,immutable" json:"target_object_type_id"`
+	TypeName           string     `db:"type_name" json:"type_name"  validate:"notempty"`
+	SourceObjectTypeID uuid.UUID  `db:"source_object_type_id,immutable" json:"source_object_type_id"  validate:"notnil"`
+	TargetObjectTypeID uuid.UUID  `db:"target_object_type_id,immutable" json:"target_object_type_id"  validate:"notnil"`
+	Attributes         Attributes `db:"attributes" json:"attributes"`
 }
 
-// Validate implements Validateable
-func (e EdgeType) Validate() error {
-	if e.TypeName == "" {
-		return ucerr.New("TypeName can't be empty")
-	}
-	if e.SourceObjectTypeID == uuid.Nil {
-		return ucerr.New("SourceObjectTypeID can't have nil ID")
-	}
-	if e.TargetObjectTypeID == uuid.Nil {
-		return ucerr.New("TargetObjectTypeID can't have nil ID")
-	}
-	return nil
-}
+//go:generate genvalidate EdgeType
 
 // Object represents an instance of an AuthZ object used for modeling permissions.
 type Object struct {
 	ucdb.BaseModel
 
-	Alias  string    `db:"alias" json:"alias"`
-	TypeID uuid.UUID `db:"type_id,immutable" json:"type_id"`
+	Alias  string    `db:"alias" json:"alias" validate:"notempty"`
+	TypeID uuid.UUID `db:"type_id,immutable" json:"type_id" validate:"notnil"`
 }
 
-// Validate implements Validateable
-func (o Object) Validate() error {
-	if o.Alias == "" {
-		return ucerr.New("Alias can't be empty")
-	}
-	if o.TypeID == uuid.Nil {
-		return ucerr.New("TypeID can't have nil ID")
-	}
-	return ucerr.Wrap(o.BaseModel.Validate())
-}
+//go:generate genvalidate Object
 
 // Edge represents a directional relationship between a "source"
 // object and a "target" object.
@@ -71,25 +100,13 @@ type Edge struct {
 	ucdb.BaseModel
 
 	// This must be a valid EdgeType.ID value
-	EdgeTypeID uuid.UUID `db:"edge_type_id" json:"edge_type_id"`
+	EdgeTypeID uuid.UUID `db:"edge_type_id" json:"edge_type_id" validate:"notnil"`
 	// These must be valid ObjectType.ID values
-	SourceObjectID uuid.UUID `db:"source_object_id" json:"source_object_id"`
-	TargetObjectID uuid.UUID `db:"target_object_id" json:"target_object_id"`
+	SourceObjectID uuid.UUID `db:"source_object_id" json:"source_object_id" validate:"notnil"`
+	TargetObjectID uuid.UUID `db:"target_object_id" json:"target_object_id" validate:"notnil"`
 }
 
-// Validate implements Validateable
-func (o Edge) Validate() error {
-	if o.EdgeTypeID == uuid.Nil {
-		return ucerr.New("EdgeTypeID can't have nil ID")
-	}
-	if o.SourceObjectID == uuid.Nil {
-		return ucerr.New("SourceObjectID can't have nil ID")
-	}
-	if o.TargetObjectID == uuid.Nil {
-		return ucerr.New("TargetObjectID can't have nil ID")
-	}
-	return ucerr.Wrap(o.BaseModel.Validate())
-}
+//go:generate genvalidate Edge
 
 // UserObject is a limited view of the `users` table used by the AuthZ service.
 // To avoid a dependency on IDP packages, AuthZ uses this stub structure to load a limited slice of User

--- a/authz/object_validate_generated.go
+++ b/authz/object_validate_generated.go
@@ -1,0 +1,23 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package authz
+
+import (
+	"github.com/gofrs/uuid"
+
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate implements Validateable
+func (o *Object) Validate() error {
+	if err := o.BaseModel.Validate(); err != nil {
+		return ucerr.Wrap(err)
+	}
+	if o.Alias == "" {
+		return ucerr.Errorf("Object.Alias (%v) can't be empty", o.ID)
+	}
+	if o.TypeID == uuid.Nil {
+		return ucerr.Errorf("Object.TypeID (%v) can't be nil", o.ID)
+	}
+	return nil
+}

--- a/authz/objecttype_validate_generated.go
+++ b/authz/objecttype_validate_generated.go
@@ -1,0 +1,18 @@
+// NOTE: automatically generated file -- DO NOT EDIT
+
+package authz
+
+import (
+	"userclouds.com/infra/ucerr"
+)
+
+// Validate implements Validateable
+func (o *ObjectType) Validate() error {
+	if err := o.BaseModel.Validate(); err != nil {
+		return ucerr.Wrap(err)
+	}
+	if o.TypeName == "" {
+		return ucerr.Errorf("ObjectType.TypeName (%v) can't be empty", o.ID)
+	}
+	return nil
+}

--- a/samples/basic/authzhelper.go
+++ b/samples/basic/authzhelper.go
@@ -33,25 +33,25 @@ func isBenign(err error) bool {
 }
 
 func provisionObjectType(ctx context.Context, authZClient *authz.Client, typeName string) (uuid.UUID, error) {
-	if _, err := authZClient.CreateObjectType(ctx, uuid.Must(uuid.NewV4()), typeName); !isBenign(err) {
-		return uuid.Nil, ucerr.Wrap(err)
-	}
 	id, err := authZClient.FindObjectTypeID(ctx, typeName)
 	if err != nil {
+		id = uuid.Must(uuid.NewV4())
+	}
+	if _, err := authZClient.CreateObjectType(ctx, id, typeName); !isBenign(err) {
 		return uuid.Nil, ucerr.Wrap(err)
 	}
-	return id, err
+	return id, nil
 }
 
-func provisionEdgeType(ctx context.Context, authZClient *authz.Client, sourceObjectID, targetObjectID uuid.UUID, typeName string) (uuid.UUID, error) {
-	if _, err := authZClient.CreateEdgeType(ctx, uuid.Must(uuid.NewV4()), sourceObjectID, targetObjectID, typeName); !isBenign(err) {
-		return uuid.Nil, ucerr.Wrap(err)
-	}
+func provisionEdgeType(ctx context.Context, authZClient *authz.Client, sourceObjectID, targetObjectID uuid.UUID, typeName string, attributes authz.Attributes) (uuid.UUID, error) {
 	id, err := authZClient.FindEdgeTypeID(ctx, typeName)
 	if err != nil {
+		id = uuid.Must(uuid.NewV4())
+	}
+	if _, err := authZClient.CreateEdgeType(ctx, id, sourceObjectID, targetObjectID, typeName, attributes); !isBenign(err) {
 		return uuid.Nil, ucerr.Wrap(err)
 	}
-	return id, err
+	return id, nil
 }
 
 func provisionObject(ctx context.Context, authZClient *authz.Client, typeID uuid.UUID, alias string) (uuid.UUID, error) {


### PR DESCRIPTION
PRs https://github.com/userclouds/userclouds/pull/406 and https://github.com/userclouds/userclouds/pull/410 added major AuthZ features (inheritance, attributes) as well as some authz client updates. This allows us to greatly simplify the permission check logic in the sample app from a looping method with lots of business logic to a simple "CheckAttribute" call.